### PR TITLE
Do not expect txHash until send, and keep history of errors

### DIFF
--- a/internal/manager/api_test.go
+++ b/internal/manager/api_test.go
@@ -111,7 +111,6 @@ func TestSendTransactionE2E(t *testing.T) {
 				assert.Len(t, prepTX.Params, 1)
 				assert.Equal(t, "4276993775", prepTX.Params[0].JSONObject().GetString("value"))
 				res = ffcapi.PrepareTransactionResponse{
-					TransactionHash: "0x106215b9c0c9372e3f541beff0cdc3cd061a26f69f3808e28fd139a1abc9d345",
 					TransactionData: "RAW_UNSIGNED_BYTES",
 					Gas:             fftypes.NewFFBigInt(2000000), // gas estimate simulation
 				}
@@ -122,9 +121,12 @@ func TestSendTransactionE2E(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, "0xb480F96c0a3d6E9e9a263e4665a39bFa6c4d01E8", sendTX.From)
 				assert.Equal(t, "0xe1a078b9e2b145d0a7387f09277c6ae1d9470771", sendTX.To)
-				assert.Equal(t, uint64(1000000), sendTX.Gas.Uint64())
+				assert.Equal(t, uint64(2000000), sendTX.Gas.Uint64())
 				assert.Equal(t, `223344556677`, sendTX.GasPrice.String())
 				assert.Equal(t, "RAW_UNSIGNED_BYTES", sendTX.TransactionData)
+				res = ffcapi.SendTransactionResponse{
+					TransactionHash: "0x106215b9c0c9372e3f541beff0cdc3cd061a26f69f3808e28fd139a1abc9d345",
+				}
 
 				// We're at end of job for this test
 				close(txSent)

--- a/internal/manager/receipt_test.go
+++ b/internal/manager/receipt_test.go
@@ -154,7 +154,7 @@ func TestCheckReceiptUpdateFFCoreWithError(t *testing.T) {
 
 	m.policyEngine = &policyenginemocks.PolicyEngine{}
 	pc := m.policyEngine.(*policyenginemocks.PolicyEngine)
-	pc.On("Execute", mock.Anything, mock.Anything, mtx).Return(false, fmt.Errorf("pop"))
+	pc.On("Execute", mock.Anything, mock.Anything, mtx).Return(false, ffcapi.ErrorReason(""), fmt.Errorf("pop"))
 
 	m.trackManaged(mtx)
 	m.checkReceipts()

--- a/internal/manager/routes.go
+++ b/internal/manager/routes.go
@@ -55,7 +55,6 @@ func (m *manager) sendManagedTransaction(ctx context.Context, request *fftm.Tran
 		ID:              request.Headers.ID, // on input the request ID must be the Operation ID
 		Nonce:           fftypes.NewFFBigInt(int64(lockedNonce.nonce)),
 		Gas:             prepared.Gas,
-		TransactionHash: prepared.TransactionHash,
 		TransactionData: prepared.TransactionData,
 		Request:         request,
 	}

--- a/internal/tmconfig/tmconfig.go
+++ b/internal/tmconfig/tmconfig.go
@@ -48,6 +48,8 @@ var (
 	OperationsFullScanPageSize = ffc("operations.fullScan.pageSize")
 	// OperationsFullScanMinimumDelay the minimum delay between full scan attempts
 	OperationsFullScanMinimumDelay = ffc("operations.fullScan.minimumDelay")
+	// OperationsErrorHistoryCount the number of errors to retain in the operation
+	OperationsErrorHistoryCount = ffc("operations.errorHistoryCount")
 	// ReceiptPollingInterval how often to poll for transaction receipts (the policy engine gets a chance to intervene for each outstanding receipt, on each polling cycle)
 	ReceiptsPollingInterval = ffc("receipts.pollingInteval")
 	// PolicyEngineName the name of the policy engine to use
@@ -76,6 +78,7 @@ func setDefaults() {
 	viper.SetDefault(string(ConfirmationsBlockCacheSize), 1000)
 	viper.SetDefault(string(ConfirmationsBlockPollingInterval), "3s")
 	viper.SetDefault(string(ConfirmationsNotificationQueueLength), 50)
+	viper.SetDefault(string(OperationsErrorHistoryCount), 25)
 	viper.SetDefault(string(ReceiptsPollingInterval), "1s")
 	viper.SetDefault(string(PolicyEngineName), "simple")
 }

--- a/internal/tmmsgs/en_config_descriptions.go
+++ b/internal/tmmsgs/en_config_descriptions.go
@@ -46,6 +46,7 @@ var (
 	ConfigOperationsFullScanMinimumDelay      = ffc("config.operations.fullScan.minimumDelay", "The minimum delay between full scans of the FireFly core API, when reconnecting, or recovering from missed events / errors", "duration")
 	ConfigOperationsFullScanPageSize          = ffc("config.operations.fullScan.pageSize", "The page size to use when performing a full scan of the ForeFly core API on startup, or recovery", "number")
 	ConfigOperationsFullScanStartupMaxRetries = ffc("config.operations.fullScan.startupMaxRetries", "The page size to use when performing a full scan of the ForeFly core API on startup, or recovery", "number")
+	ConfigOperationsErrorHistoryCount         = ffc("config.operations.errorHistoryCount", "The number of historical errors to retain in the operation", "number")
 
 	ConfigPolicyEngineName = ffc("config.policyengine.name", "The name of the policy engine to use", "string")
 

--- a/internal/tmmsgs/en_error_messges.go
+++ b/internal/tmmsgs/en_error_messges.go
@@ -35,5 +35,4 @@ var (
 	MsgErrorQueryingGasStationAPI    = ffe("FF201021", "Error from gas station API [%d]: %s")
 	MsgErrorInvalidRequest           = ffe("FF201022", "Invalid request")
 	MsgUnsupportedRequestType        = ffe("FF201023", "Unsupported request type: %s")
-	MsgTransactionHashMismatch       = ffe("FF201024", "Transaction hash mismatch ong send. Expected=%s Received=%s")
 )

--- a/mocks/policyenginemocks/policy_engine.go
+++ b/mocks/policyenginemocks/policy_engine.go
@@ -17,7 +17,7 @@ type PolicyEngine struct {
 }
 
 // Execute provides a mock function with given fields: ctx, cAPI, mtx
-func (_m *PolicyEngine) Execute(ctx context.Context, cAPI ffcapi.API, mtx *fftm.ManagedTXOutput) (bool, error) {
+func (_m *PolicyEngine) Execute(ctx context.Context, cAPI ffcapi.API, mtx *fftm.ManagedTXOutput) (bool, ffcapi.ErrorReason, error) {
 	ret := _m.Called(ctx, cAPI, mtx)
 
 	var r0 bool
@@ -27,12 +27,19 @@ func (_m *PolicyEngine) Execute(ctx context.Context, cAPI ffcapi.API, mtx *fftm.
 		r0 = ret.Get(0).(bool)
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, ffcapi.API, *fftm.ManagedTXOutput) error); ok {
+	var r1 ffcapi.ErrorReason
+	if rf, ok := ret.Get(1).(func(context.Context, ffcapi.API, *fftm.ManagedTXOutput) ffcapi.ErrorReason); ok {
 		r1 = rf(ctx, cAPI, mtx)
 	} else {
-		r1 = ret.Error(1)
+		r1 = ret.Get(1).(ffcapi.ErrorReason)
 	}
 
-	return r0, r1
+	var r2 error
+	if rf, ok := ret.Get(2).(func(context.Context, ffcapi.API, *fftm.ManagedTXOutput) error); ok {
+		r2 = rf(ctx, cAPI, mtx)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }

--- a/pkg/ffcapi/api_common.go
+++ b/pkg/ffcapi/api_common.go
@@ -56,6 +56,8 @@ const (
 	ErrorReasonInsufficientFunds ErrorReason = "insufficient_funds"
 	// ErrorReasonNotFound if the requested object (block/receipt etc.) was not found
 	ErrorReasonNotFound ErrorReason = "not_found"
+	// ErrorKnownTransaction if the exact transaction is already known
+	ErrorKnownTransaction ErrorReason = "known_transaction"
 )
 
 // Header is included consistently as a "ffcapi" structure on each request

--- a/pkg/ffcapi/prepare_transaction.go
+++ b/pkg/ffcapi/prepare_transaction.go
@@ -48,7 +48,6 @@ type PrepareTransactionRequest struct {
 type PrepareTransactionResponse struct {
 	ResponseBase
 	Gas             *fftypes.FFBigInt `json:"gas"`
-	TransactionHash string            `json:"transactionHash"`
 	TransactionData string            `json:"transactionData"`
 }
 

--- a/pkg/ffcapi/prepare_transaction_test.go
+++ b/pkg/ffcapi/prepare_transaction_test.go
@@ -25,13 +25,13 @@ import (
 
 func TestPrepareTransactionOK(t *testing.T) {
 	a, cancel := newTestClient(t, &PrepareTransactionResponse{
-		TransactionHash: "0x12345",
+		TransactionData: "0x12345",
 	})
 	defer cancel()
 	res, reason, err := a.PrepareTransaction(context.Background(), &PrepareTransactionRequest{})
 	assert.NoError(t, err)
 	assert.Empty(t, reason)
-	assert.Equal(t, "0x12345", res.TransactionHash)
+	assert.Equal(t, "0x12345", res.TransactionData)
 }
 
 func TestPrepareTransactionFail(t *testing.T) {

--- a/pkg/fftm/managed_tx.go
+++ b/pkg/fftm/managed_tx.go
@@ -22,6 +22,12 @@ import (
 	"github.com/hyperledger/firefly/pkg/fftypes"
 )
 
+type ManagedTXError struct {
+	Time   *fftypes.FFTime    `json:"time"`
+	Error  string             `json:"error,omitempty"`
+	Mapped ffcapi.ErrorReason `json:"mapped,omitempty"`
+}
+
 // ManagedTXOutput is the structure stored into the operation in FireFly, that the policy
 // engine can use to apply policy, and apply updates to
 type ManagedTXOutput struct {
@@ -37,5 +43,6 @@ type ManagedTXOutput struct {
 	LastSubmit      *fftypes.FFTime            `json:"lastSubmit,omitempty"`
 	Request         *TransactionRequest        `json:"request,omitempty"`
 	Receipt         *ffcapi.GetReceiptResponse `json:"receipt,omitempty"`
+	ErrorHistory    []*ManagedTXError          `json:"errorHistory"`
 	Confirmations   []confirmations.BlockInfo  `json:"confirmations,omitempty"`
 }

--- a/pkg/policyengine/policyengine.go
+++ b/pkg/policyengine/policyengine.go
@@ -24,5 +24,5 @@ import (
 )
 
 type PolicyEngine interface {
-	Execute(ctx context.Context, cAPI ffcapi.API, mtx *fftm.ManagedTXOutput) (updated bool, err error)
+	Execute(ctx context.Context, cAPI ffcapi.API, mtx *fftm.ManagedTXOutput) (updated bool, reason ffcapi.ErrorReason, err error)
 }


### PR DESCRIPTION
- `TransactionHash` can only be known at the `send` phase
- It's really helpful for debug to keep a rolling list of errors from the policy manager in the `Operation`