### PR TITLE
Events fixes

### DIFF
--- a/pkg/ffcapi/api.go
+++ b/pkg/ffcapi/api.go
@@ -82,12 +82,12 @@ type BlockHashEvent struct {
 
 // EventID are the set of required fields an FFCAPI compatible connector needs to map to the underlying blockchain constructs, to uniquely identify an event
 type EventID struct {
-	ListenerID       *fftypes.UUID // The listener for the event
-	BlockHash        string        // String representation of the block, which will change if any transaction info in the block changes
-	BlockNumber      uint64        // A numeric identifier for the block
-	TransactionHash  string        // The transaction
-	TransactionIndex uint64        // Index within the block of the transaction that emitted the event
-	LogIndex         uint64        // Index within the transaction of this emitted event log
+	ListenerID       *fftypes.UUID `json:"listenerId"`       // The listener for the event
+	BlockHash        string        `json:"blockHash"`        // String representation of the block, which will change if any transaction info in the block changes
+	BlockNumber      uint64        `json:"blockNumber"`      // A numeric identifier for the block
+	TransactionHash  string        `json:"transactionHash"`  // The transaction
+	TransactionIndex uint64        `json:"transactionIndex"` // Index within the block of the transaction that emitted the event
+	LogIndex         uint64        `json:"logIndex"`         // Index within the transaction of this emitted event log
 }
 
 // Event is a blockchain event that matches one of the started listeners.


### PR DESCRIPTION
This PR adds some fixes for event and receipt delivery over websockets.

### Tested and working:
🟢 Event delivery with 0 required confirmations and on demand mining (standard E2E test configuration)
🟢 Event delivery with 2 required confirmations and 2 second block period

### Tested and sometimes working:
🟡 Receipt delivery over WebSocket with 0 required confirmations and on demand mining (standard E2E test configuration). More details below.

### Tested and not working:
🔴 Receipt delivery over WebSocket with 2 required confirmations and 2 second block period. More details below

### Open questions
- Where is the right place in the code to send the WebSocket message when we have a transaction receipt to deliver? It's currently in the `receiptCallback` function in `policyLoop.go` but it's part of a `manager`. Feels like it might be the right code, but maybe the wrong file?
- I don't think I have the code quite right to handle when a transaction is "done" and confirmed. There are several states a transaction can be in, and I don't think that concept used to exist in the previous ethconnect receipt model.

### Known issues
- When required confirmations is set to `0` and using on demand mining, occasionally (seems like when I send several transactions in quick succession) it will log something like:
```
[2022-07-28T12:58:04.695-04:00] DEBUG evmconnect: Receipt for transaction 0xeb84df74d0354b91b696cf4f964e58fbf6b9f25e0df0a95186b5c1fda83bd616 not yet available
```
There is a comment at the end of that function which says:
```
// No need to keep polling - either we now have a receipt, or normal block header monitoring will pick this one up
```
However it appears that the receipt is not picked up by the normal block header monitoring, or for some reason its receipt callback function is not called. This is the yellow bullet point above.

- When required confirmations is set to `2` and using a 2 second block period, it looks like the receipt callback is never called at this point.