### PR TITLE
Ensure consistent block state during cycle, to prevent out-of-order delivery

### DIFF
--- a/config.md
+++ b/config.md
@@ -30,6 +30,18 @@ nav_order: 2
 |shutdownTimeout|The maximum amount of time to wait for any open HTTP requests to finish before shutting down the HTTP server|[`time.Duration`](https://pkg.go.dev/time#Duration)|`10s`
 |writeTimeout|The maximum time to wait when writing to a HTTP connection|[`time.Duration`](https://pkg.go.dev/time#Duration)|`15s`
 
+## api.auth
+
+|Key|Description|Type|Default Value|
+|---|-----------|----|-------------|
+|type|The auth plugin to use for server side authentication of requests|`string`|`<nil>`
+
+## api.auth.basic
+
+|Key|Description|Type|Default Value|
+|---|-----------|----|-------------|
+|passwordfile|The path to a .htpasswd file to use for authenticating requests. Passwords should be hashed with bcrypt.|`string`|`<nil>`
+
 ## api.tls
 
 |Key|Description|Type|Default Value|

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/hyperledger/firefly v1.0.1-0.20220505194321-9f59036d0b4e
-	github.com/hyperledger/firefly-common v0.1.16-0.20220801130311-02fc08199d51
+	github.com/hyperledger/firefly-common v0.1.16
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/viper v1.12.0
 	github.com/stretchr/testify v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -630,10 +630,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hyperledger/firefly v1.0.1-0.20220505194321-9f59036d0b4e h1:QP+Yykyq7C670zb4Fs7s4lAtYmvIll4rP/y00hdOsg4=
 github.com/hyperledger/firefly v1.0.1-0.20220505194321-9f59036d0b4e/go.mod h1:434LxYn4ntyK/E0dY+2dTc55caBy6BdUMYBM2gLndAI=
 github.com/hyperledger/firefly-common v0.1.2/go.mod h1:ytB+404+Qg00wJKx602Yi/V6Spx9d0g65lZR9y5fzlo=
-github.com/hyperledger/firefly-common v0.1.13 h1:eNK99U9FV43u1F46MM0mPuXT4Xn++orghpoTIIPsmwo=
-github.com/hyperledger/firefly-common v0.1.13/go.mod h1:2NqPi5Ud9H6rSlZXkLbotxW7z4EAD89p3/8oNOpm9Gs=
-github.com/hyperledger/firefly-common v0.1.16-0.20220801130311-02fc08199d51 h1:Izw9pK53kPGliZv12hCwJfP7rYILhXPx3hMNsCNv7YQ=
-github.com/hyperledger/firefly-common v0.1.16-0.20220801130311-02fc08199d51/go.mod h1:MNbaI2spBsdZYOub6Duj9xueE7Qyu9itOmJ4vE8tjYw=
+github.com/hyperledger/firefly-common v0.1.16 h1:21xidDEKrJhtGdBSRqHN4PfDi7aYxF0HOFuAa04V1AE=
+github.com/hyperledger/firefly-common v0.1.16/go.mod h1:MNbaI2spBsdZYOub6Duj9xueE7Qyu9itOmJ4vE8tjYw=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=


### PR DESCRIPTION
I realized that there was a gap in the ordering logic, in the case that there is a number of pending event waiting confirmation and we go through and do `walkChain()`.

Specifically if new blocks become available during that cycle, we might get a "hit" for a block for a later event, which was a "miss" for that block for an earlier event - simply because the block has just been mined.

So I've added a `blockState` that is created each time we do a cycle, that ensures we don't change answers on ourselves for the duration of that cycle.