### PR TITLE
Add checkpoint/catchup information from FFCAPI to listener GET API

### DIFF
--- a/pkg/apitypes/api_types.go
+++ b/pkg/apitypes/api_types.go
@@ -117,6 +117,11 @@ type Listener struct {
 	FromBlock        *string           `ffstruct:"listener" json:"fromBlock,omitempty"`
 }
 
+type ListenerWithStatus struct {
+	Listener
+	ffcapi.EventListenerHWMResponse
+}
+
 // CheckUpdateString helper merges supplied configuration, with a base, and applies a default if unset
 func CheckUpdateString(changed bool, merged **string, old *string, new *string, defValue string) bool {
 	if new != nil {

--- a/pkg/ffcapi/event_listener_hwm.go
+++ b/pkg/ffcapi/event_listener_hwm.go
@@ -27,4 +27,5 @@ type EventListenerHWMRequest struct {
 
 type EventListenerHWMResponse struct {
 	Checkpoint EventListenerCheckpoint `json:"checkpoint"`
+	Catchup    bool                    `json:"catchup,omitempty"` // informational only - informs an operator that the stream is catching up
 }

--- a/pkg/fftm/route_get_eventstream_listener_test.go
+++ b/pkg/fftm/route_get_eventstream_listener_test.go
@@ -42,6 +42,7 @@ func TestGetEventStreamsListener(t *testing.T) {
 	mfc.On("EventListenerAdd", mock.Anything, mock.Anything).Return(&ffcapi.EventListenerAddResponse{}, ffcapi.ErrorReason(""), nil)
 	mfc.On("EventListenerRemove", mock.Anything, mock.Anything).Return(&ffcapi.EventListenerRemoveResponse{}, ffcapi.ErrorReason(""), nil).Maybe()
 	mfc.On("EventStreamStopped", mock.Anything, mock.Anything).Return(&ffcapi.EventStreamStoppedResponse{}, ffcapi.ErrorReason(""), nil).Maybe()
+	mfc.On("EventListenerHWM", mock.Anything, mock.Anything).Return(&ffcapi.EventListenerHWMResponse{Catchup: true}, ffcapi.ErrorReason(""), nil).Maybe()
 
 	// Create a stream
 	var es1 apitypes.EventStream
@@ -54,7 +55,7 @@ func TestGetEventStreamsListener(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Then get it
-	var listener apitypes.Listener
+	var listener apitypes.ListenerWithStatus
 	res, err = resty.New().R().
 		SetResult(&listener).
 		Get(fmt.Sprintf("%s/eventstreams/%s/listeners/%s", url, es1.ID, l1.ID))
@@ -62,6 +63,7 @@ func TestGetEventStreamsListener(t *testing.T) {
 	assert.Equal(t, 200, res.StatusCode())
 
 	assert.Equal(t, l1.ID, listener.ID)
+	assert.True(t, listener.Catchup)
 
 	mfc.AssertExpectations(t)
 

--- a/pkg/fftm/route_get_subscription_test.go
+++ b/pkg/fftm/route_get_subscription_test.go
@@ -41,6 +41,7 @@ func TestGetSubscription(t *testing.T) {
 	mfc.On("EventListenerAdd", mock.Anything, mock.Anything).Return(&ffcapi.EventListenerAddResponse{}, ffcapi.ErrorReason(""), nil)
 	mfc.On("EventListenerRemove", mock.Anything, mock.Anything).Return(&ffcapi.EventListenerRemoveResponse{}, ffcapi.ErrorReason(""), nil).Maybe()
 	mfc.On("EventStreamStopped", mock.Anything, mock.Anything).Return(&ffcapi.EventStreamStoppedResponse{}, ffcapi.ErrorReason(""), nil).Maybe()
+	mfc.On("EventListenerHWM", mock.Anything, mock.Anything).Return(&ffcapi.EventListenerHWMResponse{Catchup: true}, ffcapi.ErrorReason(""), nil).Maybe()
 
 	// Create a stream
 	var es1 apitypes.EventStream
@@ -53,7 +54,7 @@ func TestGetSubscription(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Then get it
-	var listener apitypes.Listener
+	var listener apitypes.ListenerWithStatus
 	res, err = resty.New().R().
 		SetResult(&listener).
 		Get(url + "/subscriptions/" + l1.ID.String())
@@ -61,6 +62,7 @@ func TestGetSubscription(t *testing.T) {
 	assert.Equal(t, 200, res.StatusCode())
 
 	assert.Equal(t, l1.ID, listener.ID)
+	assert.True(t, listener.Catchup)
 
 	mfc.AssertExpectations(t)
 


### PR DESCRIPTION
Resolves #22

- Calls the existing `EventListenerHWM` endpoint in the FFCAPI and mixes that into the API response for the listener
- Adds a `catchup` flag to that API, that allows an FFCAPI implementation to mark a stream as in catchup mode