### PR TITLE
Remove the websocket.topic for simplicity and to avoid undefined behavior

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
     "badurl",
     "blocklistener",
     "ccache",
+    "Compat",
     "confirmationsmocks",
     "dataexchange",
     "Debugf",

--- a/internal/events/eventstream.go
+++ b/internal/events/eventstream.go
@@ -163,7 +163,7 @@ func (es *eventStream) initAction(startedState *startedStreamState) {
 	case apitypes.EventStreamTypeWebhook:
 		startedState.action = newWebhookAction(ctx, es.spec.Webhook).attemptBatch
 	case apitypes.EventStreamTypeWebSocket:
-		startedState.action = newWebSocketAction(es.wsChannels, es.spec.WebSocket, *es.spec.WebSocket.Topic).attemptBatch
+		startedState.action = newWebSocketAction(es.wsChannels, es.spec.WebSocket, *es.spec.Name).attemptBatch
 	default:
 		// mergeValidateEsConfig always be called previous to this
 		panic(i18n.NewError(ctx, tmmsgs.MsgInvalidStreamType, *es.spec.Type))
@@ -236,7 +236,7 @@ func mergeValidateEsConfig(ctx context.Context, base *apitypes.EventStream, upda
 	changed = apitypes.CheckUpdateEnum(changed, &merged.Type, base.Type, updates.Type, apitypes.EventStreamTypeWebSocket)
 	switch *merged.Type {
 	case apitypes.EventStreamTypeWebSocket:
-		if merged.WebSocket, changed, err = mergeValidateWsConfig(ctx, changed, *merged.Name, base.WebSocket, updates.WebSocket); err != nil {
+		if merged.WebSocket, changed, err = mergeValidateWsConfig(ctx, changed, base.WebSocket, updates.WebSocket); err != nil {
 			return nil, false, err
 		}
 	case apitypes.EventStreamTypeWebhook:

--- a/internal/events/eventstream_test.go
+++ b/internal/events/eventstream_test.go
@@ -135,10 +135,7 @@ func TestConfigNewDefaultsUpdate(t *testing.T) {
 	InitDefaults()
 
 	es := testESConf(t, `{
-		"name":  "test1",
-		"websocket": {
-			"topic": "test1"
-		}
+		"name":  "test1"
 	}`)
 	es, changed, err := mergeValidateEsConfig(context.Background(), nil, es)
 	assert.NoError(t, err)
@@ -159,8 +156,7 @@ func TestConfigNewDefaultsUpdate(t *testing.T) {
 		"suspended":false,
 		"type":"websocket",
 		"websocket": {
-			"distributionMode":"load_balance",
-			"topic":"test1"
+			"distributionMode":"load_balance"
 		}
 	}`, string(b))
 

--- a/internal/events/websockets.go
+++ b/internal/events/websockets.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hyperledger/firefly-transaction-manager/pkg/apitypes"
 )
 
-func mergeValidateWsConfig(ctx context.Context, changed bool, esName string, base *apitypes.WebSocketConfig, updates *apitypes.WebSocketConfig) (*apitypes.WebSocketConfig, bool, error) {
+func mergeValidateWsConfig(ctx context.Context, changed bool, base *apitypes.WebSocketConfig, updates *apitypes.WebSocketConfig) (*apitypes.WebSocketConfig, bool, error) {
 
 	if base == nil {
 		base = &apitypes.WebSocketConfig{}
@@ -46,9 +46,6 @@ func mergeValidateWsConfig(ctx context.Context, changed bool, esName string, bas
 	default:
 		return nil, false, i18n.NewError(ctx, tmmsgs.MsgInvalidDistributionMode, *merged.DistributionMode)
 	}
-
-	// Topic
-	changed = apitypes.CheckUpdateString(changed, &merged.Topic, base.Topic, updates.Topic, esName /* default to the ES name */)
 
 	return merged, changed, nil
 }

--- a/pkg/apitypes/api_types.go
+++ b/pkg/apitypes/api_types.go
@@ -99,7 +99,6 @@ type WebhookConfig struct {
 
 type WebSocketConfig struct {
 	DistributionMode *DistributionMode `ffstruct:"wsconfig" json:"distributionMode,omitempty"`
-	Topic            *string           `ffstruct:"wsconfig" json:"topic,omitempty"`
 }
 
 type Listener struct {


### PR DESCRIPTION
The original intention during EVMConnect was to remove this field, because the behavior around it in EthConnect was confusing.
- It had to be unique to each Event Stream
- We didn't enforce it to be unique
- If it wasn't unique, the behavior was undefined

However, we thought that compatibility/migration in FireFly Core and the ERC-20/ERC-721 and ERC-1155 token connectors would be a pain. So we put it back in...

We've since worked through all that in the tokens thanks to @awrichar in the following PRs, so this PR pulls it back out again:
- FireFly Core Ethereum Connector: ???
- ERC-1155: https://github.com/hyperledger/firefly-tokens-erc1155/pull/94
- ERC-20/ERC-721: https://github.com/hyperledger/firefly-tokens-erc20-erc721/pull/83
