### PR TITLE
Fix hang broadcasting to broken connection

### DIFF
--- a/internal/ws/wsserver.go
+++ b/internal/ws/wsserver.go
@@ -224,6 +224,10 @@ func (s *webSocketServer) processReplies() {
 
 func (s *webSocketServer) broadcastToConnections(connections []*webSocketConnection, message interface{}) {
 	for _, c := range connections {
-		c.broadcast <- message
+		select {
+		case c.broadcast <- message:
+		case <-c.closing:
+			log.L(s.ctx).Warnf("Connection %s closed while attempting to deliver reply", c.id)
+		}
 	}
 }

--- a/internal/ws/wsserver_test.go
+++ b/internal/ws/wsserver_test.go
@@ -369,3 +369,20 @@ func TestListenTopicClosing(t *testing.T) {
 		topic: "test",
 	})
 }
+
+func TestBroadcastClosing(t *testing.T) {
+
+	w, ts := newTestWebSocketServer()
+	defer ts.Close()
+	w.getTopic("test")
+
+	c := &webSocketConnection{
+		server:   w,
+		topics:   make(map[string]*webSocketTopic),
+		closing:  make(chan struct{}),
+		newTopic: make(chan bool),
+	}
+	close(c.closing)
+	// Check this doesn't block
+	c.server.broadcastToConnections([]*webSocketConnection{c}, "anything")
+}

--- a/pkg/fftm/api.go
+++ b/pkg/fftm/api.go
@@ -83,13 +83,8 @@ func (m *manager) runAPIServer() {
 }
 
 func (m *manager) runDebugServer() {
-	var debugServer *http.Server
 	debugPort := config.GetInt(tmconfig.DebugPort)
-
 	defer func() {
-		if debugServer != nil {
-			_ = debugServer.Close()
-		}
 		close(m.debugServerDone)
 	}()
 
@@ -100,8 +95,8 @@ func (m *manager) runDebugServer() {
 		r.PathPrefix("/debug/pprof/symbol").HandlerFunc(pprof.Symbol)
 		r.PathPrefix("/debug/pprof/trace").HandlerFunc(pprof.Trace)
 		r.PathPrefix("/debug/pprof/").HandlerFunc(pprof.Index)
-		debugServer = &http.Server{Addr: fmt.Sprintf("localhost:%d", debugPort), Handler: r, ReadHeaderTimeout: 30 * time.Second}
+		m.debugServer = &http.Server{Addr: fmt.Sprintf("localhost:%d", debugPort), Handler: r, ReadHeaderTimeout: 30 * time.Second}
 		log.L(m.ctx).Debugf("Debug HTTP endpoint listening on localhost:%d", debugPort)
-		_ = debugServer.ListenAndServe()
+		_ = m.debugServer.ListenAndServe()
 	}
 }

--- a/pkg/fftm/api_test.go
+++ b/pkg/fftm/api_test.go
@@ -22,8 +22,10 @@ import (
 	"testing"
 
 	"github.com/go-resty/resty/v2"
+	"github.com/hyperledger/firefly-common/pkg/config"
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-transaction-manager/internal/confirmations"
+	"github.com/hyperledger/firefly-transaction-manager/internal/tmconfig"
 	"github.com/hyperledger/firefly-transaction-manager/mocks/confirmationsmocks"
 	"github.com/hyperledger/firefly-transaction-manager/mocks/ffcapimocks"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/apitypes"
@@ -148,7 +150,7 @@ func TestSendTransactionE2E(t *testing.T) {
 
 }
 
-func TestDeployTransactionE2E(t *testing.T) {
+func TestDeployTransactionE2EWithDebugServer(t *testing.T) {
 
 	txSent := make(chan struct{})
 
@@ -195,6 +197,7 @@ func TestDeployTransactionE2E(t *testing.T) {
 		return n.NotificationType == confirmations.NewTransaction
 	})).Return(nil)
 
+	config.Set(tmconfig.DebugPort, 0)
 	m.Start()
 
 	req := strings.NewReader(sampleDeployTX)

--- a/pkg/fftm/manager.go
+++ b/pkg/fftm/manager.go
@@ -18,6 +18,7 @@ package fftm
 
 import (
 	"context"
+	"net/http"
 	"sync"
 	"time"
 
@@ -87,6 +88,7 @@ type manager struct {
 	blockListenerDone       chan struct{}
 	started                 bool
 	apiServerDone           chan error
+	debugServer             *http.Server
 	debugServerDone         chan struct{}
 
 	policyLoopInterval time.Duration
@@ -199,6 +201,9 @@ func (m *manager) Close() {
 	m.cancelCtx()
 	if m.started {
 		m.started = false
+		if m.debugServer != nil {
+			m.debugServer.Close()
+		}
 		<-m.apiServerDone
 		<-m.policyLoopDone
 		<-m.blockListenerDone

--- a/pkg/fftm/policyloop.go
+++ b/pkg/fftm/policyloop.go
@@ -237,6 +237,7 @@ func (m *manager) execPolicy(ctx context.Context, pending *pendingState, syncDel
 				log.L(ctx).Errorf("Policy engine returned error for transaction %s reason=%s: %s", mtx.ID, reason, err)
 				m.addError(mtx, reason, err)
 			} else {
+				log.L(ctx).Debugf("Policy engine executed for tx %s (update=%d,status=%s,hash=%s)", mtx.ID, update, mtx.Status, mtx.TransactionHash)
 				if mtx.FirstSubmit != nil && pending.trackingTransactionHash != mtx.TransactionHash {
 					// If now submitted, add to confirmations manager for receipt checking
 					m.trackSubmittedTransaction(ctx, pending)
@@ -257,6 +258,7 @@ func (m *manager) execPolicy(ctx context.Context, pending *pendingState, syncDel
 			}
 			if completed {
 				pending.remove = true // for the next time round the loop
+				log.L(ctx).Errorf("Transaction %s marked complete (status=%s): %s", mtx.ID, mtx.Status, err)
 				m.markInflightStale()
 			}
 		case policyengine.UpdateDelete:


### PR DESCRIPTION
Policy loop blocked...

```
goroutine 46 [chan send, 19 minutes]:
github.com/hyperledger/firefly-transaction-manager/internal/ws.(*webSocketServer).SendReply(0x1159540?, {0xa51b80?, 0xc001592140?})
	/go/pkg/mod/github.com/hyperledger/firefly-transaction-manager@v0.9.8/internal/ws/wsserver.go:163 +0x36
github.com/hyperledger/firefly-transaction-manager/pkg/fftm.(*manager).sendWSReply(0xc000369180, 0xc0015e8ea0)
	/go/pkg/mod/github.com/hyperledger/firefly-transaction-manager@v0.9.8/pkg/fftm/policyloop.go:293 +0x195
github.com/hyperledger/firefly-transaction-manager/pkg/fftm.(*manager).execPolicy(0xc000369180, {0xd803b8, 0xc0001d0210}, 0xc001d4be40, 0x0)
	/go/pkg/mod/github.com/hyperledger/firefly-transaction-manager@v0.9.8/pkg/fftm/policyloop.go:271 +0x7bf
github.com/hyperledger/firefly-transaction-manager/pkg/fftm.(*manager).policyLoopCycle(0xc000369180, {0xd803b8, 0xc0001d0210}, 0x1)
	/go/pkg/mod/github.com/hyperledger/firefly-transaction-manager@v0.9.8/pkg/fftm/policyloop.go:123 +0xf5
github.com/hyperledger/firefly-transaction-manager/pkg/fftm.(*manager).policyLoop(0xc000369180)
	/go/pkg/mod/github.com/hyperledger/firefly-transaction-manager@v0.9.8/pkg/fftm/policyloop.go:45 +0x1c6
created by github.com/hyperledger/firefly-transaction-manager/pkg/fftm.(*manager).Start
	/go/pkg/mod/github.com/hyperledger/firefly-transaction-manager@v0.9.8/pkg/fftm/manager.go:191 +0x26a
```

... by broadcast channel ...

```
goroutine 20 [chan send, 19 minutes]:
github.com/hyperledger/firefly-transaction-manager/internal/ws.(*webSocketServer).broadcastToConnections(...)
	/go/pkg/mod/github.com/hyperledger/firefly-transaction-manager@v0.9.8/internal/ws/wsserver.go:227
github.com/hyperledger/firefly-transaction-manager/internal/ws.(*webSocketServer).processReplies(0xc000129260)
	/go/pkg/mod/github.com/hyperledger/firefly-transaction-manager@v0.9.8/internal/ws/wsserver.go:221 +0x25e
created by github.com/hyperledger/firefly-transaction-manager/internal/ws.NewWebSocketServer
	/go/pkg/mod/github.com/hyperledger/firefly-transaction-manager@v0.9.8/internal/ws/wsserver.go:83 +0x216
```

I assert this is due to attempting to dispatch to a closed websocket connection.