### PR TITLE
Pass options.signer for EthCompat mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/hyperledger/firefly-transaction-manager
 go 1.17
 
 require (
+	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/getkin/kin-openapi v0.96.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-resty/resty/v2 v2.7.0
@@ -20,7 +21,6 @@ require (
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
-	github.com/Masterminds/sprig/v3 v3.2.2 // indirect
 	github.com/aidarkhanov/nanoid v1.0.8 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/go-units v0.4.0 // indirect

--- a/pkg/fftm/stream_management.go
+++ b/pkg/fftm/stream_management.go
@@ -419,6 +419,7 @@ func mergeEthCompatMethods(ctx context.Context, listener *apitypes.Listener) err
 			return err
 		}
 		optionsMap["methods"] = methodList
+		optionsMap["signer"] = true // the EthCompat support extracts the signer automatically when you choose methods (was just one option)
 		b, _ := json.Marshal(optionsMap)
 		listener.Options = fftypes.JSONAnyPtrBytes(b)
 		listener.EthCompatMethods = nil

--- a/pkg/fftm/stream_management_test.go
+++ b/pkg/fftm/stream_management_test.go
@@ -626,7 +626,7 @@ func TestMergeEthCompatMethods(t *testing.T) {
 	assert.NoError(t, err)
 	b, err := json.Marshal(l.Options)
 	assert.NoError(t, err)
-	assert.JSONEq(t, `{"methods": [{"method1":"awesomeMethod"}], "otherOption":"otherValue"}`, string(b))
+	assert.JSONEq(t, `{"methods": [{"method1":"awesomeMethod"}], "signer":true, "otherOption":"otherValue"}`, string(b))
 	assert.Nil(t, l.EthCompatMethods)
 
 	l = &apitypes.Listener{
@@ -637,7 +637,7 @@ func TestMergeEthCompatMethods(t *testing.T) {
 	assert.NoError(t, err)
 	b, err = json.Marshal(l.Options)
 	assert.NoError(t, err)
-	assert.JSONEq(t, `{"methods": [{"method1":"awesomeMethod"}]}`, string(b))
+	assert.JSONEq(t, `{"methods": [{"method1":"awesomeMethod"}],"signer":true}`, string(b))
 	assert.Nil(t, l.EthCompatMethods)
 }
 


### PR DESCRIPTION
EVMConnect will separate out the option `options.signer: true` from the `options.methods: []` list of methods to match, so you can just request `signer`. Also so that even if no methods match we still set the signer.

This means a tweak to the EthCompat mode