### PR TITLE
Update FF every time there is an error, or interesting change in state

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,6 @@ github.com/hashicorp/serf v0.9.7/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpT
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.1 h1:4jgBlKK6tLKFvO8u5pmYjG91cqytmDCDvGh7ECVFfFs=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
-github.com/hyperledger/firefly-common v0.1.17-0.20220808193503-961a6b241a1a h1:KQJuUGh4CdZ5XXwKjyY9M0hm//uqwcUkwpxkiIEaziQ=
-github.com/hyperledger/firefly-common v0.1.17-0.20220808193503-961a6b241a1a/go.mod h1:MNbaI2spBsdZYOub6Duj9xueE7Qyu9itOmJ4vE8tjYw=
 github.com/hyperledger/firefly-common v1.1.3 h1:srCodaJSLl8/qaq+Cse6HfHZbzYFzguerX370YGxnXU=
 github.com/hyperledger/firefly-common v1.1.3/go.mod h1:gMlv4Iy5JjnzXmSEdb+tWVDIc/2GhL9MRcgNX+VmI4M=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -382,8 +380,6 @@ github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144T
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
-github.com/pelletier/go-toml/v2 v2.0.1 h1:8e3L2cCQzLFi2CR4g7vGFuFxX7Jl1kKX8gW+iV0GUKU=
-github.com/pelletier/go-toml/v2 v2.0.1/go.mod h1:r9LEWfGN8R5k0VXJ+0BkIe7MYkRdwZOjgMj2KwnJFUo=
 github.com/pelletier/go-toml/v2 v2.0.2 h1:+jQXlF3scKIcSEKkdHzXhCTDLPFi5r1wnK6yPS+49Gw=
 github.com/pelletier/go-toml/v2 v2.0.2/go.mod h1:MovirKjgVRESsAvNZlAjtFwV867yGuwRkXbG66OzopI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -441,14 +437,10 @@ github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmq
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/spf13/viper v1.12.0 h1:CZ7eSOd3kZoaYDLbXnmzgQI5RlciuXBMA+18HwHRfZQ=
-github.com/spf13/viper v1.12.0/go.mod h1:b6COn30jlNxbm/V2IqWiNWkJ+vZNiMNksliPCiuKtSI=
 github.com/spf13/viper v1.12.1-0.20220712161005-5247643f0235 h1:azjn5/lAGpcMny6s1fW/y6rXTu2YUOA+a2C6wKpgpkw=
 github.com/spf13/viper v1.12.1-0.20220712161005-5247643f0235/go.mod h1:f40df4ovE8V1ot0NXmYP1zUDS+X1D5AXGviq9fCJqZU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
-github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.4.0 h1:M2gUjqZET1qApGOWNSnZ49BAIMX4F/1plDv3+l31EJ4=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -457,12 +449,10 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/subosito/gotenv v1.3.0/go.mod h1:YzJjq/33h7nrwdY+iHMhEOEEbW0ovIz0tB6t6PwAXzs=
 github.com/subosito/gotenv v1.4.0 h1:yAzM1+SmVcz5R4tXGsNMu1jUl2aOJXoiWUCEwwnGrvs=
 github.com/subosito/gotenv v1.4.0/go.mod h1:mZd6rFysKEcUhUHXJk0C/08wAgyDBFuwEYL7vWWGaGo=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=

--- a/pkg/apitypes/managed_tx.go
+++ b/pkg/apitypes/managed_tx.go
@@ -17,6 +17,8 @@
 package apitypes
 
 import (
+	"fmt"
+
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-transaction-manager/internal/confirmations"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
@@ -34,10 +36,30 @@ const (
 	TxStatusFailed TxStatus = "Failed"
 )
 
-type ManagedTXError struct {
-	Time   *fftypes.FFTime    `json:"time"`
-	Error  string             `json:"error,omitempty"`
-	Mapped ffcapi.ErrorReason `json:"mapped,omitempty"`
+type ManagedTXUpdate struct {
+	Time           *fftypes.FFTime    `json:"time"`
+	LastOccurrence *fftypes.FFTime    `json:"lastOccurrence"`
+	Count          int                `json:"count"`
+	Info           string             `json:"info,omitempty"`
+	Error          string             `json:"error,omitempty"`
+	MappedReason   ffcapi.ErrorReason `json:"reason,omitempty"`
+}
+
+// MsgString is assured to be the same, as long as the type/message is the same.
+// Does not change if the count/times are different - so allows comparison.
+func (mtu *ManagedTXUpdate) MsgString() string {
+	if mtu == nil {
+		return ""
+	}
+	msg := ""
+	if mtu.Error != "" {
+		msg = fmt.Sprintf("error: %s, ", mtu.Error)
+	}
+	if mtu.MappedReason != "" {
+		msg += fmt.Sprintf("reason: %s, ", mtu.MappedReason)
+	}
+	msg += fmt.Sprintf("info: %s", mtu.Info)
+	return msg
 }
 
 // ManagedTX is the structure stored for each new transaction request, using the external ID of the operation
@@ -74,7 +96,7 @@ type ManagedTX struct {
 	LastSubmit         *fftypes.FFTime                    `json:"lastSubmit,omitempty"`
 	Receipt            *ffcapi.TransactionReceiptResponse `json:"receipt,omitempty"`
 	ErrorMessage       string                             `json:"errorMessage,omitempty"`
-	ErrorHistory       []*ManagedTXError                  `json:"errorHistory"`
+	History            []*ManagedTXUpdate                 `json:"history"`
 	Confirmations      []confirmations.BlockInfo          `json:"confirmations,omitempty"`
 }
 

--- a/pkg/apitypes/managed_tx_test.go
+++ b/pkg/apitypes/managed_tx_test.go
@@ -1,0 +1,104 @@
+// Copyright © 2022 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apitypes
+
+import (
+	"testing"
+
+	"github.com/hyperledger/firefly-common/pkg/fftypes"
+	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestManagedTXUpdateMsgStringEqual(t *testing.T) {
+
+	assert.Empty(t, ((*ManagedTXUpdate)(nil)).MsgString())
+	mtu1 := ManagedTXUpdate{
+		Time:           fftypes.Now(),
+		LastOccurrence: fftypes.Now(),
+		Count:          10,
+		Info:           "things happened",
+		Error:          "it was bad",
+		MappedReason:   ffcapi.ErrorKnownTransaction,
+	}
+	mtu2 := ManagedTXUpdate{
+		Time:           fftypes.Now(),
+		LastOccurrence: fftypes.Now(),
+		Count:          1,
+		Info:           "things happened",
+		Error:          "it was bad",
+		MappedReason:   ffcapi.ErrorKnownTransaction,
+	}
+	assert.Equal(t, mtu1.MsgString(), mtu2.MsgString())
+}
+
+func TestManagedTXUpdateMsgStringNotMatchErr(t *testing.T) {
+
+	mtu1 := ManagedTXUpdate{
+		Time:           fftypes.Now(),
+		LastOccurrence: fftypes.Now(),
+		Count:          10,
+		Info:           "things happened",
+		Error:          "it was bad",
+		MappedReason:   ffcapi.ErrorKnownTransaction,
+	}
+	mtu2 := ManagedTXUpdate{
+		Time:           fftypes.Now(),
+		LastOccurrence: fftypes.Now(),
+		Count:          1,
+		Info:           "things happened",
+		Error:          "it was more bad",
+		MappedReason:   ffcapi.ErrorKnownTransaction,
+	}
+	assert.NotEqual(t, mtu1.MsgString(), mtu2.MsgString())
+}
+
+func TestManagedTXUpdateMsgStringNotMatchReason(t *testing.T) {
+
+	mtu1 := ManagedTXUpdate{
+		Time:           fftypes.Now(),
+		LastOccurrence: fftypes.Now(),
+		Count:          10,
+		Info:           "things happened",
+		MappedReason:   ffcapi.ErrorKnownTransaction,
+	}
+	mtu2 := ManagedTXUpdate{
+		Time:           fftypes.Now(),
+		LastOccurrence: fftypes.Now(),
+		Count:          1,
+		Info:           "things happened",
+		MappedReason:   "",
+	}
+	assert.NotEqual(t, mtu1.MsgString(), mtu2.MsgString())
+}
+
+func TestManagedTXUpdateMsgStringNotMatchInfo(t *testing.T) {
+
+	mtu1 := ManagedTXUpdate{
+		Time:           fftypes.Now(),
+		LastOccurrence: fftypes.Now(),
+		Count:          10,
+		Info:           "things happened",
+	}
+	mtu2 := ManagedTXUpdate{
+		Time:           fftypes.Now(),
+		LastOccurrence: fftypes.Now(),
+		Count:          1,
+		Info:           "then we were done",
+	}
+	assert.NotEqual(t, mtu1.MsgString(), mtu2.MsgString())
+}

--- a/pkg/ffcapi/api.go
+++ b/pkg/ffcapi/api.go
@@ -134,6 +134,13 @@ func (eid *EventID) ProtocolID() string {
 	return fmt.Sprintf("%.12d/%.6d/%.6d", eid.BlockNumber, eid.TransactionIndex, eid.LogIndex)
 }
 
+func ProtocolIDForReceipt(receipt *TransactionReceiptResponse) string {
+	if receipt == nil {
+		return ""
+	}
+	return fmt.Sprintf("%.12d/%.6d", receipt.BlockNumber.Int(), receipt.TransactionIndex.Int())
+}
+
 // Events array has a natural sort order of the block/txIndex/logIndex
 type Events []*Event
 

--- a/pkg/ffcapi/api_test.go
+++ b/pkg/ffcapi/api_test.go
@@ -55,3 +55,13 @@ func TestSortEvents(t *testing.T) {
 		assert.LessOrEqual(t, strings.Compare(listenerUpdates[i-1].Event.ID.ProtocolID(), listenerUpdates[i].Event.ID.ProtocolID()), 0)
 	}
 }
+
+func TestProtocolIDForReceipt(t *testing.T) {
+	var receipt *TransactionReceiptResponse
+	assert.Empty(t, ProtocolIDForReceipt(receipt))
+	receipt = &TransactionReceiptResponse{
+		BlockNumber:      fftypes.NewFFBigInt(12345),
+		TransactionIndex: fftypes.NewFFBigInt(42),
+	}
+	assert.Equal(t, "000000012345/000042", ProtocolIDForReceipt(receipt))
+}

--- a/pkg/fftm/manager_test.go
+++ b/pkg/fftm/manager_test.go
@@ -161,32 +161,55 @@ func TestNewManagerBadPolicyEngine(t *testing.T) {
 
 }
 
-func TestAddErrorMessageMax(t *testing.T) {
+func TestAddHistoryEntryMax(t *testing.T) {
 
 	_, m, close := newTestManagerMockPersistence(t)
 	defer close()
 
 	m.errorHistoryCount = 2
 	mtx := &apitypes.ManagedTX{}
-	m.addError(mtx, ffcapi.ErrorReasonTransactionUnderpriced, fmt.Errorf("snap"))
-	m.addError(mtx, ffcapi.ErrorReasonTransactionUnderpriced, fmt.Errorf("crackle"))
-	m.addError(mtx, ffcapi.ErrorReasonTransactionUnderpriced, fmt.Errorf("pop"))
-	assert.Len(t, mtx.ErrorHistory, 2)
-	assert.Equal(t, "pop", mtx.ErrorHistory[0].Error)
-	assert.Equal(t, "crackle", mtx.ErrorHistory[1].Error)
+	m.updateHistory(mtx, "", fmt.Errorf("snap"), ffcapi.ErrorReasonTransactionUnderpriced)
+	for i := 0; i < 20; i++ {
+		m.updateHistory(mtx, "", fmt.Errorf("crackle"), ffcapi.ErrorReasonTransactionUnderpriced)
+	}
+	m.updateHistory(mtx, "", fmt.Errorf("pop"), ffcapi.ErrorReasonTransactionUnderpriced)
+	assert.False(t, m.updateHistory(mtx, "", nil, "")) // ignored
+	assert.Len(t, mtx.History, 2)
+	assert.Equal(t, "pop", mtx.History[0].Error)
+	assert.Equal(t, "crackle", mtx.History[1].Error)
 
 }
 
-func TestStartRestoreFail(t *testing.T) {
+func TestAddHistoryEntryDups(t *testing.T) {
+
+	_, m, close := newTestManagerMockPersistence(t)
+	defer close()
+
+	m.errorHistoryCount = 2
+	mtx := &apitypes.ManagedTX{}
+	m.updateHistory(mtx, "some info", fmt.Errorf("snap"), ffcapi.ErrorReasonTransactionUnderpriced)
+	for i := 0; i < 20; i++ {
+		m.updateHistory(mtx, "some info", fmt.Errorf("crackle"), ffcapi.ErrorReasonTransactionUnderpriced)
+	}
+	m.updateHistory(mtx, "some info", fmt.Errorf("pop"), ffcapi.ErrorReasonTransactionUnderpriced)
+	assert.Len(t, mtx.History, 2)
+	assert.Equal(t, "pop", mtx.History[0].Error)
+	assert.Equal(t, 1, mtx.History[0].Count)
+	assert.Equal(t, "crackle", mtx.History[1].Error)
+	assert.Equal(t, 20, mtx.History[1].Count)
+
+}
+
+func TestStartListListenersFail(t *testing.T) {
 	_, m, close := newTestManagerMockPersistence(t)
 	defer close()
 
 	mp := m.persistence.(*persistencemocks.Persistence)
-	mp.On("ListStreams", mock.Anything, mock.Anything, startupPaginationLimit, persistence.SortDirectionAscending).
-		Return(nil, fmt.Errorf("pop"))
+	mp.On("ListStreams", mock.Anything, mock.Anything, startupPaginationLimit, persistence.SortDirectionAscending).Return(nil, fmt.Errorf("pop"))
 
 	err := m.Start()
 	assert.Regexp(t, "pop", err)
+
 }
 
 func TestStartBlockListenerFail(t *testing.T) {

--- a/pkg/fftm/policyloop.go
+++ b/pkg/fftm/policyloop.go
@@ -203,7 +203,6 @@ func (m *manager) updateHistory(mtx *apitypes.ManagedTX, info string, err error,
 		MappedReason: reason,
 		Count:        1,
 	}
-	newEntry.LastOccurrence = newEntry.Time
 
 	// Set or clear the error message - on the entry, and the top-level TX
 	if err != nil {
@@ -244,10 +243,7 @@ func (m *manager) execPolicy(ctx context.Context, pending *pendingState, syncDel
 	m.mux.Lock()
 	mtx := pending.mtx
 	confirmed := pending.confirmed
-	receipt := ""
-	if pending.mtx.Receipt != nil {
-		receipt = pending.mtx.Receipt.TransactionIndex.String()
-	}
+	receipt := ffcapi.ProtocolIDForReceipt(mtx.Receipt)
 	if syncDeleteRequest && mtx.DeleteRequested == nil {
 		mtx.DeleteRequested = fftypes.Now()
 	}
@@ -260,7 +256,7 @@ func (m *manager) execPolicy(ctx context.Context, pending *pendingState, syncDel
 	case receipt != "" && confirmed && !syncDeleteRequest:
 		update = policyengine.UpdateYes
 		completed = true
-		updateInfo = fmt.Sprintf("Receipt=%s,Success=%t,Confirmations=%d,Hash=%s", receipt, mtx.Receipt.Success, len(mtx.Confirmations), mtx.TransactionHash)
+		updateInfo = fmt.Sprintf("Success=%t,Receipt=%s,Confirmations=%d,Hash=%s", mtx.Receipt.Success, receipt, len(mtx.Confirmations), mtx.TransactionHash)
 		if pending.mtx.Receipt.Success {
 			mtx.Status = apitypes.TxStatusSucceeded
 		} else {

--- a/pkg/fftm/policyloop.go
+++ b/pkg/fftm/policyloop.go
@@ -18,6 +18,7 @@ package fftm
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -186,23 +187,52 @@ func (m *manager) processPolicyAPIRequests(ctx context.Context) {
 
 }
 
-func (m *manager) addError(mtx *apitypes.ManagedTX, reason ffcapi.ErrorReason, err error) {
-	newLen := len(mtx.ErrorHistory) + 1
+// updateHistory applies an update to the object, and returns if a new item was added
+// to the history.
+func (m *manager) updateHistory(mtx *apitypes.ManagedTX, info string, err error, reason ffcapi.ErrorReason) bool {
+
+	if info == "" && err == nil {
+		return false
+	}
+
+	// Initialize a new entry
+	mtx.Updated = fftypes.Now()
+	newEntry := &apitypes.ManagedTXUpdate{
+		Time:         mtx.Updated,
+		Info:         info,
+		MappedReason: reason,
+		Count:        1,
+	}
+	newEntry.LastOccurrence = newEntry.Time
+
+	// Set or clear the error message - on the entry, and the top-level TX
+	if err != nil {
+		newEntry.Error = err.Error()
+		mtx.ErrorMessage = err.Error()
+	} else {
+		mtx.ErrorMessage = ""
+	}
+
+	// Check if we just need to increment the last occurrence and count on the latest
+	if len(mtx.History) > 0 && mtx.History[0].MsgString() == newEntry.MsgString() {
+		existingEntry := mtx.History[0]
+		existingEntry.Count++
+		existingEntry.LastOccurrence = mtx.Updated
+		return err != nil // Always store error count bumps
+	}
+
+	// Otherwise extend the list - newest first
+	newLen := len(mtx.History) + 1
 	if newLen > m.errorHistoryCount {
 		newLen = m.errorHistoryCount
 	}
-	oldHistory := mtx.ErrorHistory
-	mtx.ErrorHistory = make([]*apitypes.ManagedTXError, newLen)
-	latestError := &apitypes.ManagedTXError{
-		Time:   fftypes.Now(),
-		Mapped: reason,
-		Error:  err.Error(),
-	}
-	mtx.ErrorMessage = latestError.Error
-	mtx.ErrorHistory[0] = latestError
+	oldHistory := mtx.History
+	mtx.History = make([]*apitypes.ManagedTXUpdate, newLen)
+	mtx.History[0] = newEntry
 	for i := 1; i < newLen; i++ {
-		mtx.ErrorHistory[i] = oldHistory[i-1]
+		mtx.History[i] = oldHistory[i-1]
 	}
+	return true
 }
 
 func (m *manager) execPolicy(ctx context.Context, pending *pendingState, syncDeleteRequest bool) (err error) {
@@ -214,21 +244,28 @@ func (m *manager) execPolicy(ctx context.Context, pending *pendingState, syncDel
 	m.mux.Lock()
 	mtx := pending.mtx
 	confirmed := pending.confirmed
+	receipt := ""
+	if pending.mtx.Receipt != nil {
+		receipt = pending.mtx.Receipt.TransactionIndex.String()
+	}
 	if syncDeleteRequest && mtx.DeleteRequested == nil {
 		mtx.DeleteRequested = fftypes.Now()
 	}
 	m.mux.Unlock()
 
+	var updateErr error
+	var updateReason ffcapi.ErrorReason
+	var updateInfo string
 	switch {
-	case confirmed && !syncDeleteRequest:
+	case receipt != "" && confirmed && !syncDeleteRequest:
 		update = policyengine.UpdateYes
 		completed = true
-		if mtx.Receipt.Success {
+		updateInfo = fmt.Sprintf("Receipt=%s,Success=%t,Confirmations=%d,Hash=%s", receipt, mtx.Receipt.Success, len(mtx.Confirmations), mtx.TransactionHash)
+		if pending.mtx.Receipt.Success {
 			mtx.Status = apitypes.TxStatusSucceeded
-			mtx.ErrorMessage = ""
 		} else {
 			mtx.Status = apitypes.TxStatusFailed
-			mtx.ErrorMessage = i18n.NewError(ctx, tmmsgs.MsgTransactionFailed).Error()
+			updateErr = i18n.NewError(ctx, tmmsgs.MsgTransactionFailed)
 		}
 
 	default:
@@ -239,13 +276,12 @@ func (m *manager) execPolicy(ctx context.Context, pending *pendingState, syncDel
 		if syncDeleteRequest || time.Since(pending.lastPolicyCycle) > m.policyLoopInterval {
 			// Pass the state to the pluggable policy engine to potentially perform more actions against it,
 			// such as submitting for the first time, or raising the gas etc.
-			var reason ffcapi.ErrorReason
-			update, reason, err = m.policyEngine.Execute(ctx, m.connector, pending.mtx)
-			if err != nil {
-				log.L(ctx).Errorf("Policy engine returned error for transaction %s reason=%s: %s", mtx.ID, reason, err)
-				m.addError(mtx, reason, err)
+			update, updateReason, updateErr = m.policyEngine.Execute(ctx, m.connector, pending.mtx)
+			if updateErr != nil {
+				log.L(ctx).Errorf("Policy engine returned error for transaction %s reason=%s: %s", mtx.ID, updateReason, err)
 				update = policyengine.UpdateYes
 			} else {
+				updateInfo = fmt.Sprintf("Submitted=%t,Receipt=%s,Hash=%s", mtx.FirstSubmit != nil, receipt, mtx.TransactionHash)
 				log.L(ctx).Debugf("Policy engine executed for tx %s (update=%d,status=%s,hash=%s)", mtx.ID, update, mtx.Status, mtx.TransactionHash)
 				if mtx.FirstSubmit != nil && pending.trackingTransactionHash != mtx.TransactionHash {
 					// If now submitted, add to confirmations manager for receipt checking
@@ -256,9 +292,17 @@ func (m *manager) execPolicy(ctx context.Context, pending *pendingState, syncDel
 		}
 	}
 
+	infoChanged := m.updateHistory(mtx, updateInfo, updateErr, updateReason)
+	if infoChanged && update == policyengine.UpdateNo {
+		// TODO: The interface with policy engine could do with enhancing, including
+		//       reconciling FireFly core issue 1108. For now, if the policy engine
+		//       doesn't mark an update, but the info we have about the TX changed
+		//       due to receipt/confirmations popping in or then we publish an update.
+		update = policyengine.UpdateYes
+	}
+
 	switch update {
 	case policyengine.UpdateYes:
-		mtx.Updated = fftypes.Now()
 		err := m.persistence.WriteTransaction(ctx, mtx, false)
 		if err != nil {
 			log.L(ctx).Errorf("Failed to update transaction %s (status=%s): %s", mtx.ID, mtx.Status, err)


### PR DESCRIPTION
Note this is an interim change, and we should fully implement https://github.com/hyperledger/firefly/issues/1108 such that only a transition of the _state_ to `Error` would result in a WebSocket update (not simply us writing an error to our local state from a single execution of the polling loop).

This PR:
1. Fixes the problem that we didn't propagate error updates at all
2. Introduces a more complete history list, that includes when we submitted the transaction, when we got a receipt etc.

