### PR TITLE
Reduce the size of websocket updates for transactions.

### DIFF
--- a/internal/confirmations/confirmations_test.go
+++ b/internal/confirmations/confirmations_test.go
@@ -347,6 +347,7 @@ func TestBlockConfirmationManagerE2ETransactionMovedFork(t *testing.T) {
 		BlockHash:        block1002a.ParentHash,
 		BlockNumber:      fftypes.NewFFBigInt(1001),
 		TransactionIndex: fftypes.NewFFBigInt(0),
+		ProtocolID:       fmt.Sprintf("%.12d/%.6d", fftypes.NewFFBigInt(1001).Int64(), fftypes.NewFFBigInt(0).Int64()),
 		Success:          true,
 	}, ffcapi.ErrorReason(""), nil).Once()
 
@@ -385,6 +386,7 @@ func TestBlockConfirmationManagerE2ETransactionMovedFork(t *testing.T) {
 		BlockHash:        block1001b.BlockHash,
 		BlockNumber:      fftypes.NewFFBigInt(1001),
 		TransactionIndex: fftypes.NewFFBigInt(0),
+		ProtocolID:       fmt.Sprintf("%.12d/%.6d", fftypes.NewFFBigInt(1001).Int64(), fftypes.NewFFBigInt(0).Int64()),
 		Success:          true,
 	}, ffcapi.ErrorReason(""), nil).Once()
 
@@ -962,6 +964,7 @@ func TestCheckReceiptImmediateConfirm(t *testing.T) {
 		BlockHash:        fftypes.NewRandB32().String(),
 		BlockNumber:      fftypes.NewFFBigInt(1001),
 		TransactionIndex: fftypes.NewFFBigInt(0),
+		ProtocolID:       fmt.Sprintf("%.12d/%.6d", fftypes.NewFFBigInt(1001).Int64(), fftypes.NewFFBigInt(0).Int64()),
 		Success:          true,
 	}, ffcapi.ErrorReasonNotFound, nil)
 
@@ -1009,6 +1012,7 @@ func TestCheckReceiptWalkFail(t *testing.T) {
 		BlockNumber:      fftypes.NewFFBigInt(12345),
 		BlockHash:        "0x64fd8179b80dd255d52ce60d7f265c0506be810e2f3df52463fadeb44bb4d2df",
 		TransactionIndex: fftypes.NewFFBigInt(10),
+		ProtocolID:       fmt.Sprintf("%.12d/%.6d", fftypes.NewFFBigInt(12345).Int64(), fftypes.NewFFBigInt(10).Int64()),
 	}, ffcapi.ErrorReason(""), nil)
 	mca.On("BlockInfoByNumber", mock.Anything, mock.MatchedBy(func(r *ffcapi.BlockInfoByNumberRequest) bool {
 		return r.BlockNumber.Uint64() == 12346

--- a/pkg/apitypes/managed_tx.go
+++ b/pkg/apitypes/managed_tx.go
@@ -43,14 +43,15 @@ type ManagedTXError struct {
 // ManagedTX is the structure stored for each new transaction request, using the external ID of the operation
 //
 // Indexing:
-//   Multiple index collection are stored for the managed transactions, to allow them to be managed including:
 //
-//   - Nonce allocation: this is a critical index, and why cleanup is so important (mentioned below).
-//     We use this index to determine the next nonce to assign to a given signing key.
-//   - Created time: a timestamp ordered index for the transactions for convenient ordering.
-//     the key includes the ID of the TX for uniqueness.
-//   - Pending sequence: An entry in this index only exists while the transaction is pending, and is
-//     ordered by a UUIDv1 sequence allocated to each entry.
+//	Multiple index collection are stored for the managed transactions, to allow them to be managed including:
+//
+//	- Nonce allocation: this is a critical index, and why cleanup is so important (mentioned below).
+//	  We use this index to determine the next nonce to assign to a given signing key.
+//	- Created time: a timestamp ordered index for the transactions for convenient ordering.
+//	  the key includes the ID of the TX for uniqueness.
+//	- Pending sequence: An entry in this index only exists while the transaction is pending, and is
+//	  ordered by a UUIDv1 sequence allocated to each entry.
 //
 // Index cleanup after partial write:
 //   - All indexes are stored before the TX itself.
@@ -93,8 +94,12 @@ type ReplyHeaders struct {
 
 // TransactionUpdateReply add a "headers" structure that allows a processor of websocket
 // replies/updates to filter on a standard structure to know how to process the message.
-// Extensible to update update types in the future.
+// Extensible to update types in the future. The reply is a small summary of the
+// latest status change. Full status for a transaction must be retrieved with
+// /transactions/{txid}
 type TransactionUpdateReply struct {
-	Headers ReplyHeaders `json:"headers"`
-	ManagedTX
+	Headers         ReplyHeaders `json:"headers"`
+	Status          TxStatus     `json:"status"`
+	ProtocolID      string       `json:"protocolId"`
+	TransactionHash string       `json:"transactionHash,omitempty"`
 }

--- a/pkg/ffcapi/api.go
+++ b/pkg/ffcapi/api.go
@@ -134,6 +134,13 @@ func (eid *EventID) ProtocolID() string {
 	return fmt.Sprintf("%.12d/%.6d/%.6d", eid.BlockNumber, eid.TransactionIndex, eid.LogIndex)
 }
 
+func ProtocolIDForReceipt(receipt *TransactionReceiptResponse) string {
+	if receipt == nil {
+		return ""
+	}
+	return fmt.Sprintf("%.12d/%.6d", receipt.BlockNumber.Int(), receipt.TransactionIndex.Int())
+}
+
 // Events array has a natural sort order of the block/txIndex/logIndex
 type Events []*Event
 

--- a/pkg/ffcapi/api.go
+++ b/pkg/ffcapi/api.go
@@ -134,13 +134,6 @@ func (eid *EventID) ProtocolID() string {
 	return fmt.Sprintf("%.12d/%.6d/%.6d", eid.BlockNumber, eid.TransactionIndex, eid.LogIndex)
 }
 
-func ProtocolIDForReceipt(receipt *TransactionReceiptResponse) string {
-	if receipt == nil {
-		return ""
-	}
-	return fmt.Sprintf("%.12d/%.6d", receipt.BlockNumber.Int(), receipt.TransactionIndex.Int())
-}
-
 // Events array has a natural sort order of the block/txIndex/logIndex
 type Events []*Event
 

--- a/pkg/ffcapi/api_test.go
+++ b/pkg/ffcapi/api_test.go
@@ -55,13 +55,3 @@ func TestSortEvents(t *testing.T) {
 		assert.LessOrEqual(t, strings.Compare(listenerUpdates[i-1].Event.ID.ProtocolID(), listenerUpdates[i].Event.ID.ProtocolID()), 0)
 	}
 }
-
-func TestProtocolIDForReceipt(t *testing.T) {
-	var receipt *TransactionReceiptResponse
-	assert.Empty(t, ProtocolIDForReceipt(receipt))
-	receipt = &TransactionReceiptResponse{
-		BlockNumber:      fftypes.NewFFBigInt(12345),
-		TransactionIndex: fftypes.NewFFBigInt(42),
-	}
-	assert.Equal(t, "000000012345/000042", ProtocolIDForReceipt(receipt))
-}

--- a/pkg/ffcapi/transaction_receipt.go
+++ b/pkg/ffcapi/transaction_receipt.go
@@ -29,5 +29,6 @@ type TransactionReceiptResponse struct {
 	TransactionIndex *fftypes.FFBigInt `json:"transactionIndex"`
 	BlockHash        string            `json:"blockHash"`
 	Success          bool              `json:"success"`
+	ProtocolID       string            `json:"protocolId"`
 	ExtraInfo        *fftypes.JSONAny  `json:"extraInfo"`
 }

--- a/pkg/fftm/policyloop.go
+++ b/pkg/fftm/policyloop.go
@@ -238,12 +238,17 @@ func (m *manager) execPolicy(ctx context.Context, pending *pendingState, syncDel
 
 	update := policyengine.UpdateNo
 	completed := false
+	var receiptProtocolID string
 
 	// Check whether this has been confirmed by the confirmation manager
 	m.mux.Lock()
 	mtx := pending.mtx
+	if mtx.Receipt != nil {
+		receiptProtocolID = mtx.Receipt.ProtocolID
+	} else {
+		receiptProtocolID = ""
+	}
 	confirmed := pending.confirmed
-	receipt := ffcapi.ProtocolIDForReceipt(mtx.Receipt)
 	if syncDeleteRequest && mtx.DeleteRequested == nil {
 		mtx.DeleteRequested = fftypes.Now()
 	}
@@ -253,10 +258,10 @@ func (m *manager) execPolicy(ctx context.Context, pending *pendingState, syncDel
 	var updateReason ffcapi.ErrorReason
 	var updateInfo string
 	switch {
-	case receipt != "" && confirmed && !syncDeleteRequest:
+	case receiptProtocolID != "" && confirmed && !syncDeleteRequest:
 		update = policyengine.UpdateYes
 		completed = true
-		updateInfo = fmt.Sprintf("Success=%t,Receipt=%s,Confirmations=%d,Hash=%s", mtx.Receipt.Success, receipt, len(mtx.Confirmations), mtx.TransactionHash)
+		updateInfo = fmt.Sprintf("Success=%t,Receipt=%s,Confirmations=%d,Hash=%s", mtx.Receipt.Success, receiptProtocolID, len(mtx.Confirmations), mtx.TransactionHash)
 		if pending.mtx.Receipt.Success {
 			mtx.Status = apitypes.TxStatusSucceeded
 		} else {
@@ -277,7 +282,7 @@ func (m *manager) execPolicy(ctx context.Context, pending *pendingState, syncDel
 				log.L(ctx).Errorf("Policy engine returned error for transaction %s reason=%s: %s", mtx.ID, updateReason, err)
 				update = policyengine.UpdateYes
 			} else {
-				updateInfo = fmt.Sprintf("Submitted=%t,Receipt=%s,Hash=%s", mtx.FirstSubmit != nil, receipt, mtx.TransactionHash)
+				updateInfo = fmt.Sprintf("Submitted=%t,Receipt=%s,Hash=%s", mtx.FirstSubmit != nil, receiptProtocolID, mtx.TransactionHash)
 				log.L(ctx).Debugf("Policy engine executed for tx %s (update=%d,status=%s,hash=%s)", mtx.ID, update, mtx.Status, mtx.TransactionHash)
 				if mtx.FirstSubmit != nil && pending.trackingTransactionHash != mtx.TransactionHash {
 					// If now submitted, add to confirmations manager for receipt checking
@@ -335,7 +340,12 @@ func (m *manager) sendWSReply(mtx *apitypes.ManagedTX) {
 		Status:          mtx.Status,
 		TransactionHash: mtx.TransactionHash,
 	}
-	wsr.ProtocolID = ffcapi.ProtocolIDForReceipt(mtx.Receipt)
+
+	if mtx.Receipt != nil {
+		wsr.ProtocolID = mtx.Receipt.ProtocolID
+	} else {
+		wsr.ProtocolID = ""
+	}
 
 	switch mtx.Status {
 	case apitypes.TxStatusSucceeded:

--- a/pkg/fftm/policyloop_test.go
+++ b/pkg/fftm/policyloop_test.go
@@ -89,6 +89,7 @@ func TestPolicyLoopE2EOk(t *testing.T) {
 			BlockNumber:      fftypes.NewFFBigInt(12345),
 			TransactionIndex: fftypes.NewFFBigInt(10),
 			BlockHash:        fftypes.NewRandB32().String(),
+			ProtocolID:       fmt.Sprintf("%.12d/%.6d", fftypes.NewFFBigInt(12345).Int64(), fftypes.NewFFBigInt(10).Int64()),
 			Success:          true,
 		})
 		n.Transaction.Confirmed(context.Background(), []confirmations.BlockInfo{})
@@ -140,6 +141,7 @@ func TestPolicyLoopE2EReverted(t *testing.T) {
 			BlockNumber:      fftypes.NewFFBigInt(12345),
 			TransactionIndex: fftypes.NewFFBigInt(10),
 			BlockHash:        fftypes.NewRandB32().String(),
+			ProtocolID:       fmt.Sprintf("%.12d/%.6d", fftypes.NewFFBigInt(12345).Int64(), fftypes.NewFFBigInt(10).Int64()),
 			Success:          false,
 		})
 		n.Transaction.Confirmed(context.Background(), []confirmations.BlockInfo{})
@@ -211,6 +213,7 @@ func TestPolicyLoopResubmitNewTXID(t *testing.T) {
 			BlockNumber:      fftypes.NewFFBigInt(12345),
 			TransactionIndex: fftypes.NewFFBigInt(10),
 			BlockHash:        fftypes.NewRandB32().String(),
+			ProtocolID:       fmt.Sprintf("%.12d/%.6d", fftypes.NewFFBigInt(12345).Int64(), fftypes.NewFFBigInt(10).Int64()),
 			Success:          true,
 		})
 		n.Transaction.Confirmed(context.Background(), []confirmations.BlockInfo{})


### PR DESCRIPTION
Subscribers can use /transactions/{txid} to provide full detail about a transaction if required.

Delivered as part of closing https://github.com/hyperledger/firefly/issues/1108

Signed-off-by: Matthew Whitehead <matthew.whitehead@kaleido.io>