### PR TITLE
Bring FFTM back to 100% test coverage

### DIFF
--- a/pkg/fftm/manager.go
+++ b/pkg/fftm/manager.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -105,10 +105,6 @@ type manager struct {
 func InitConfig() {
 	tmconfig.Reset()
 	events.InitDefaults()
-
-	if config.GetBool(tmconfig.MetricsEnabled) {
-		metrics.Registry()
-	}
 }
 
 func NewManager(ctx context.Context, connector ffcapi.API) (Manager, error) {

--- a/pkg/fftm/policyloop_test.go
+++ b/pkg/fftm/policyloop_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -315,7 +315,7 @@ func TestPolicyLoopUpdateFail(t *testing.T) {
 
 func TestPolicyEngineFailStaleThenUpdated(t *testing.T) {
 
-	_, m, cancel := newTestManager(t)
+	_, m, cancel := newTestManagerWithMetrics(t)
 	defer cancel()
 	m.policyLoopInterval = 1 * time.Hour
 
@@ -345,6 +345,8 @@ func TestPolicyEngineFailStaleThenUpdated(t *testing.T) {
 	<-done1
 
 	<-done2
+
+	m.Close()
 
 	mpe.AssertExpectations(t)
 


### PR DESCRIPTION
Signed-off-by: Matthew Whitehead <matthew1001@gmail.com>

When I added prometheus metrics to FFTM I didn't maintain 100% test coverage, so this PR addresses that and has us back at 100%.