### PR TITLE
Add contractLocation field to transaction output

### DIFF
--- a/pkg/apitypes/managed_tx.go
+++ b/pkg/apitypes/managed_tx.go
@@ -161,8 +161,9 @@ type ReplyHeaders struct {
 // latest status change. Full status for a transaction must be retrieved with
 // /transactions/{txid}
 type TransactionUpdateReply struct {
-	Headers         ReplyHeaders `json:"headers"`
-	Status          TxStatus     `json:"status"`
-	ProtocolID      string       `json:"protocolId"`
-	TransactionHash string       `json:"transactionHash,omitempty"`
+	Headers          ReplyHeaders     `json:"headers"`
+	Status           TxStatus         `json:"status"`
+	ProtocolID       string           `json:"protocolId"`
+	TransactionHash  string           `json:"transactionHash,omitempty"`
+	ContractLocation *fftypes.JSONAny `json:"contractLocation,omitempty"`
 }

--- a/pkg/ffcapi/transaction_receipt.go
+++ b/pkg/ffcapi/transaction_receipt.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -31,4 +31,5 @@ type TransactionReceiptResponse struct {
 	Success          bool              `json:"success"`
 	ProtocolID       string            `json:"protocolId"`
 	ExtraInfo        *fftypes.JSONAny  `json:"extraInfo"`
+	ContractLocation *fftypes.JSONAny  `json:"contractLocation"`
 }

--- a/pkg/fftm/policyloop.go
+++ b/pkg/fftm/policyloop.go
@@ -300,6 +300,10 @@ func (m *manager) sendWSReply(mtx *apitypes.ManagedTX) {
 		TransactionHash: mtx.TransactionHash,
 	}
 
+	if mtx.Receipt != nil && mtx.Receipt.ContractLocation != nil {
+		wsr.ContractLocation = mtx.Receipt.ContractLocation
+	}
+
 	if mtx.Receipt != nil {
 		wsr.ProtocolID = mtx.Receipt.ProtocolID
 	} else {

--- a/pkg/fftm/policyloop_test.go
+++ b/pkg/fftm/policyloop_test.go
@@ -92,6 +92,7 @@ func TestPolicyLoopE2EOk(t *testing.T) {
 			BlockHash:        fftypes.NewRandB32().String(),
 			ProtocolID:       fmt.Sprintf("%.12d/%.6d", fftypes.NewFFBigInt(12345).Int64(), fftypes.NewFFBigInt(10).Int64()),
 			Success:          true,
+			ContractLocation: fftypes.JSONAnyPtr(`{"address": "0x24746b95d118b2b4e8d07b06b1bad988fbf9415d"}`),
 		})
 		n.Transaction.Confirmed(context.Background(), []confirmations.BlockInfo{})
 	}).Return(nil)


### PR DESCRIPTION
This (combined with an upcoming PR in Evmconnect and FireFly Core) brings the contract address of a deployed contract all the way through to the transaction output. This shows up in a `JSONAny` field called `contractLocation` and looks like this in FireFly:

```json
...
    "output": {
        "Headers": {
            "requestId": "default:aa155a3c-2591-410e-bc9d-68ae7de34689",
            "type": "TransactionSuccess"
        },
        "contractLocation": {
            "address": "0x24746b95d118b2b4e8d07b06b1bad988fbf9415d"
        },
        "protocolId": "000000000024/000000",
        "transactionHash": "0x32d1144091877266d7f0426e48db157e7d1a857c62e6f488319bb09243f0f851"
    },
...
```