### PR TITLE
test: use `t.TempDir` to create temporary test directory

### DIFF
--- a/internal/persistence/dbmigration/leveldb2postgres_test.go
+++ b/internal/persistence/dbmigration/leveldb2postgres_test.go
@@ -94,25 +94,22 @@ func TestMigrateLevelDBToPostgres(t *testing.T) {
 	defer done()
 
 	// Configure a test LevelDB
-	dir, err := os.MkdirTemp("", "ldb_*")
-	assert.NoError(t, err)
+	dir := t.TempDir()
 	config.Set(tmconfig.PersistenceLevelDBPath, dir)
 
 	// Run empty migration and check no errors
-	err = MigrateLevelDBToPostgres(ctx)
+	err := MigrateLevelDBToPostgres(ctx)
 	assert.NoError(t, err)
-
 }
 
 func TestMigrateLevelDBToPostgresFailPSQL(t *testing.T) {
 	tmconfig.Reset()
 
 	// Configure a test LevelDB
-	dir, err := os.MkdirTemp("", "ldb_*")
-	assert.NoError(t, err)
+	dir := t.TempDir()
 	config.Set(tmconfig.PersistenceLevelDBPath, dir)
 
-	err = MigrateLevelDBToPostgres(context.Background())
+	err := MigrateLevelDBToPostgres(context.Background())
 	assert.Regexp(t, "FF21049", err)
 }
 

--- a/internal/persistence/leveldb/leveldb_persistence_test.go
+++ b/internal/persistence/leveldb/leveldb_persistence_test.go
@@ -39,8 +39,7 @@ func newTestLevelDBPersistence(t *testing.T) (context.Context, *leveldbPersisten
 
 	ctx, cancelCtx := context.WithCancel(context.Background())
 
-	dir, err := os.MkdirTemp("", "ldb_*")
-	assert.NoError(t, err)
+	dir := t.TempDir()
 
 	tmconfig.Reset()
 	config.Set(tmconfig.PersistenceLevelDBPath, dir)
@@ -62,7 +61,6 @@ func newTestLevelDBPersistence(t *testing.T) (context.Context, *leveldbPersisten
 
 	return ctx, p, func() {
 		p.Close(ctx)
-		os.RemoveAll(dir)
 		cancelCtx()
 	}
 

--- a/pkg/fftm/manager_test.go
+++ b/pkg/fftm/manager_test.go
@@ -81,8 +81,7 @@ func newTestManager(t *testing.T) (string, *manager, func()) {
 
 	url := testManagerCommonInit(t, false)
 
-	dir, err := os.MkdirTemp("", "ldb_*")
-	assert.NoError(t, err)
+	dir := t.TempDir()
 	config.Set(tmconfig.PersistenceLevelDBPath, dir)
 
 	mca := &ffcapimocks.API{}
@@ -99,7 +98,6 @@ func newTestManager(t *testing.T) (string, *manager, func()) {
 		m,
 		func() {
 			m.Close()
-			os.RemoveAll(dir)
 		}
 }
 
@@ -167,8 +165,7 @@ func newTestManagerWithMetrics(t *testing.T) (string, *manager, func()) {
 
 	url := testManagerCommonInit(t, true)
 
-	dir, err := os.MkdirTemp("", "ldb_*")
-	assert.NoError(t, err)
+	dir := t.TempDir()
 	config.Set(tmconfig.PersistenceLevelDBPath, dir)
 
 	mca := &ffcapimocks.API{}
@@ -185,7 +182,6 @@ func newTestManagerWithMetrics(t *testing.T) (string, *manager, func()) {
 		m,
 		func() {
 			m.Close()
-			os.RemoveAll(dir)
 		}
 }
 
@@ -251,15 +247,13 @@ func TestNewManagerBadHttpConfig(t *testing.T) {
 
 	tmconfig.Reset()
 	tmconfig.APIConfig.Set(httpserver.HTTPConfAddress, "::::")
-	dir, err := os.MkdirTemp("", "ldb_*")
-	defer os.RemoveAll(dir)
-	assert.NoError(t, err)
+	dir := t.TempDir()
 	config.Set(tmconfig.PersistenceLevelDBPath, dir)
 
 	txRegistry.RegisterHandler(&simple.TransactionHandlerFactory{})
 	tmconfig.TransactionHandlerBaseConfig.SubSection("simple").Set(simple.FixedGasPrice, "223344556677")
 
-	_, err = NewManager(context.Background(), nil)
+	_, err := NewManager(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Regexp(t, "FF00151", err)
 
@@ -300,13 +294,11 @@ func TestNewManagerBadPersistenceConfig(t *testing.T) {
 func TestNewManagerInvalidTransactionHandlerName(t *testing.T) {
 
 	tmconfig.Reset()
-	dir, err := os.MkdirTemp("", "ldb_*")
-	defer os.RemoveAll(dir)
-	assert.NoError(t, err)
+	dir := t.TempDir()
 	config.Set(tmconfig.PersistenceLevelDBPath, dir)
 	config.Set(tmconfig.TransactionsHandlerName, "wrong")
 
-	_, err = NewManager(context.Background(), nil)
+	_, err := NewManager(context.Background(), nil)
 	assert.Regexp(t, "FF21070", err)
 
 }
@@ -335,15 +327,13 @@ func TestNewManagerWithMetricsBadConfig(t *testing.T) {
 
 	tmconfig.MetricsConfig.Set("enabled", true)
 	tmconfig.MetricsConfig.Set(httpserver.HTTPConfAddress, "::::")
-	dir, err := os.MkdirTemp("", "ldb_*")
-	defer os.RemoveAll(dir)
-	assert.NoError(t, err)
+	dir := t.TempDir()
 	config.Set(tmconfig.PersistenceLevelDBPath, dir)
 
 	txRegistry.RegisterHandler(&simple.TransactionHandlerFactory{})
 	tmconfig.TransactionHandlerBaseConfig.SubSection("simple").Set(simple.FixedGasPrice, "223344556677")
 
-	_, err = NewManager(context.Background(), nil)
+	_, err := NewManager(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Regexp(t, "FF00151", err)
 }

--- a/pkg/txhandler/simple/policyloop_test.go
+++ b/pkg/txhandler/simple/policyloop_test.go
@@ -100,8 +100,7 @@ func sendSampleDeployment(t *testing.T, sth *simpleTransactionHandler, signer st
 }
 
 func TestPolicyLoopE2EOk(t *testing.T) {
-	f, tk, _, conf, cleanup := newTestTransactionHandlerFactoryWithFilePersistence(t)
-	defer cleanup()
+	f, tk, _, conf := newTestTransactionHandlerFactoryWithFilePersistence(t)
 	conf.Set(FixedGasPrice, `12345`)
 	conf.Set(ResubmitInterval, "100s")
 	th, err := f.NewTransactionHandler(context.Background(), conf)
@@ -170,8 +169,7 @@ func TestPolicyLoopE2EOk(t *testing.T) {
 }
 
 func TestPolicyLoopIgnoreTransactionInformationalEventHandlingErrors(t *testing.T) {
-	f, tk, _, conf, cleanup := newTestTransactionHandlerFactoryWithFilePersistence(t)
-	defer cleanup()
+	f, tk, _, conf := newTestTransactionHandlerFactoryWithFilePersistence(t)
 	conf.Set(FixedGasPrice, `12345`)
 	conf.Set(ResubmitInterval, "100s")
 	th, err := f.NewTransactionHandler(context.Background(), conf)
@@ -228,8 +226,7 @@ func TestPolicyLoopIgnoreTransactionInformationalEventHandlingErrors(t *testing.
 }
 
 func TestTransactionPreparationErrors(t *testing.T) {
-	f, tk, _, conf, cleanup := newTestTransactionHandlerFactoryWithFilePersistence(t)
-	defer cleanup()
+	f, tk, _, conf := newTestTransactionHandlerFactoryWithFilePersistence(t)
 	conf.Set(FixedGasPrice, `12345`)
 	conf.Set(ResubmitInterval, "100s")
 	th, err := f.NewTransactionHandler(context.Background(), conf)
@@ -272,8 +269,7 @@ func TestTransactionPreparationErrors(t *testing.T) {
 
 func TestPolicyLoopE2EReverted(t *testing.T) {
 
-	f, tk, _, conf, cleanup := newTestTransactionHandlerFactoryWithFilePersistence(t)
-	defer cleanup()
+	f, tk, _, conf := newTestTransactionHandlerFactoryWithFilePersistence(t)
 	conf.Set(FixedGasPrice, `12345`)
 	conf.Set(ResubmitInterval, "100s")
 	th, err := f.NewTransactionHandler(context.Background(), conf)
@@ -355,8 +351,7 @@ func TestPolicyLoopE2EReverted(t *testing.T) {
 }
 
 func TestPolicyLoopResubmitNewTXID(t *testing.T) {
-	f, tk, _, conf, cleanup := newTestTransactionHandlerFactoryWithFilePersistence(t)
-	defer cleanup()
+	f, tk, _, conf := newTestTransactionHandlerFactoryWithFilePersistence(t)
 	conf.Set(FixedGasPrice, `12345`)
 	conf.Set(ResubmitInterval, "100s")
 	conf.Set(Interval, "0")
@@ -444,8 +439,7 @@ func TestPolicyLoopResubmitNewTXID(t *testing.T) {
 
 func TestNotifyConfirmationMgrFail(t *testing.T) {
 
-	f, tk, _, conf, cleanup := newTestTransactionHandlerFactoryWithFilePersistence(t)
-	defer cleanup()
+	f, tk, _, conf := newTestTransactionHandlerFactoryWithFilePersistence(t)
 	conf.Set(FixedGasPrice, `12345`)
 	conf.Set(ResubmitInterval, "100s")
 	th, err := f.NewTransactionHandler(context.Background(), conf)
@@ -700,8 +694,7 @@ func TestPolicyLoopUpdateEventHandlerError(t *testing.T) {
 }
 
 func TestPolicyEngineFailStaleThenUpdated(t *testing.T) {
-	f, tk, mockFFCAPI, conf, cleanup := newTestTransactionHandlerFactoryWithFilePersistence(t)
-	defer cleanup()
+	f, tk, mockFFCAPI, conf := newTestTransactionHandlerFactoryWithFilePersistence(t)
 	conf.SubSection(GasOracleConfig).Set(GasOracleMode, GasOracleModeConnector)
 	th, err := f.NewTransactionHandler(context.Background(), conf)
 	assert.NoError(t, err)


### PR DESCRIPTION
This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `t.TempDir` function from the `testing` package to create temporary directory. The directory created by `t.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	dir, err := ioutil.TempDir("", "")
	assert.NoError(t, err)
	defer os.RemoveAll(dir)

	// now
	dir := t.TempDir()
}
```