### PR TITLE
Provide a way for policy engines to pass additional state to callbacks

### DIFF
--- a/pkg/apitypes/managed_tx.go
+++ b/pkg/apitypes/managed_tx.go
@@ -273,6 +273,10 @@ type ManagedTransactionEvent struct {
 	Type    ManagedTransactionEventType
 	Tx      *ManagedTX
 	Receipt *ffcapi.TransactionReceiptResponse
+	// ReceiptHandler can be passed on the event as a closure with extra variables
+	ReceiptHandler func(ctx context.Context, txID string, receipt *ffcapi.TransactionReceiptResponse) error
+	// ConfirmationHandler can be passed on the event as a closure with extra variables
+	ConfirmationHandler func(ctx context.Context, txID string, notification *ConfirmationsNotification) error
 }
 
 type ReceiptRecord struct {

--- a/pkg/fftm/transaction_events_handler_test.go
+++ b/pkg/fftm/transaction_events_handler_test.go
@@ -112,6 +112,7 @@ func TestHandleTransactionHashUpdateEventAddHash(t *testing.T) {
 		return n.NotificationType == confirmations.NewTransaction
 	})).Return(nil).Once()
 	eh.ConfirmationManager = mcm
+	eh.TxHandler = &txhandlermocks.TransactionHandler{}
 	testTx := &apitypes.ManagedTX{
 		ID:         fmt.Sprintf("ns1:%s", fftypes.NewUUID()),
 		Created:    fftypes.Now(),


### PR DESCRIPTION
Provides an alternative approach the 2nd item in #91 , allowing any policy engine implementation to pass a closure in with additional variables it's safe for that implementation to pass through. For example, a transaction-specific context object.