### PR TITLE
Fix confirmations incremental dispatch 

### DIFF
--- a/pkg/txhandler/simple/policyloop.go
+++ b/pkg/txhandler/simple/policyloop.go
@@ -495,6 +495,7 @@ func (sth *simpleTransactionHandler) HandleTransactionConfirmations(ctx context.
 	pending.confirmed = notification.Confirmed
 	pending.confirmNotify = fftypes.Now()
 	pending.confirmations = notification
+	log.L(ctx).Infof("Received %d confirmations (resync=%t)", len(notification.Confirmations), notification.NewFork)
 	sth.mux.Unlock()
 
 	sth.markInflightUpdate()


### PR DESCRIPTION
~In PR chain with #93 ~
~Also contains commit from #96 ~
Rebased on main with 93/96 merged to aid review

I found that we were re-dispatching the whole set of confirmations each time, in the incremental case where `NewFork: false`