### PR TITLE
Fixing a nonce conflict issue when the cached nonce expired.

### DIFF
--- a/internal/persistence/postgres/transaction_writer.go
+++ b/internal/persistence/postgres/transaction_writer.go
@@ -330,11 +330,11 @@ func (tw *transactionWriter) assignNonces(ctx context.Context, txInsertsByFrom m
 					}
 					if len(existingTXs) > 0 {
 						internalNextNonce = existingTXs[0].Nonce.Uint64() + 1
-						log.L(ctx).Tracef("Using the existing nonce from DB %s / %d to compare with the queried next %d for transaction %s", signer, internalNextNonce, nextNonce, op.txInsert.ID)
+						log.L(ctx).Tracef("Using the next nonce calculated from DB %s / %d to compare with the queried next %d for transaction %s", signer, internalNextNonce, nextNonce, op.txInsert.ID)
 					}
 				}
 				if internalNextNonce > nextNonce {
-					log.L(ctx).Infof("Using next nonce %s / %d instead of queried next %d for transaction %s", signer, internalNextNonce+1, nextNonce, op.txInsert.ID)
+					log.L(ctx).Infof("Using next nonce %s / %d instead of queried next %d for transaction %s", signer, internalNextNonce, nextNonce, op.txInsert.ID)
 					nextNonce = internalNextNonce
 				}
 				// Now we can cache the newly calculated value, and just increment as we go through all the TX in this batch

--- a/internal/persistence/postgres/transaction_writer_test.go
+++ b/internal/persistence/postgres/transaction_writer_test.go
@@ -135,23 +135,74 @@ func TestExecuteBatchOpsInsertTXFailOverrideNonceBelowTx(t *testing.T) {
 	mdb.ExpectBegin()
 	mdb.ExpectQuery("SELECT.*").WillReturnRows(newTXRow(p))
 	mdb.ExpectExec("INSERT.*").WillReturnResult(driver.ResultNoRows)
+	mdb.ExpectExec("INSERT.*").WillReturnResult(driver.ResultNoRows)
 	mdb.ExpectCommit()
 
-	tx := &apitypes.ManagedTX{
+	// batch 1
+	tx1 := &apitypes.ManagedTX{
 		TransactionHeaders: ffcapi.TransactionHeaders{From: "0x12345"},
 	}
+	tx2 := &apitypes.ManagedTX{
+		TransactionHeaders: ffcapi.TransactionHeaders{From: "0x12345"},
+	}
+
+	// a different batch so that they will retrieve the cached nonce
+	txa := &apitypes.ManagedTX{
+		TransactionHeaders: ffcapi.TransactionHeaders{From: "0x12345"},
+	}
+	txb := &apitypes.ManagedTX{
+		TransactionHeaders: ffcapi.TransactionHeaders{From: "0x12345"},
+	}
+
 	p.writer.runBatch(ctx, &transactionWriterBatch{
 		ops: []*transactionOperation{
 			{
 				txID:     "1",
-				txInsert: tx,
+				txInsert: tx1,
+				nextNonceCB: func(ctx context.Context, signer string) (uint64, error) {
+					return 1 /* below nonce 11111 in the row queried back */, nil
+				},
+				done: make(chan error, 1)},
+			{
+				txID:     "2",
+				txInsert: tx2,
 				nextNonceCB: func(ctx context.Context, signer string) (uint64, error) {
 					return 1 /* below nonce 11111 in the row queried back */, nil
 				},
 				done: make(chan error, 1)},
 		},
 	})
-	assert.Equal(t, uint64(0x11112), tx.Nonce.Uint64())
+
+	mdb.ExpectBegin()
+	mdb.ExpectQuery("SELECT.*").WillReturnRows(newTXRow(p))
+	mdb.ExpectExec("INSERT.*").WillReturnResult(driver.ResultNoRows)
+	mdb.ExpectExec("INSERT.*").WillReturnResult(driver.ResultNoRows)
+	mdb.ExpectCommit()
+	p.nonceStateTimeout = 0 // set expiry to 0 so nonceCallback will be queried
+	p.writer.runBatch(ctx, &transactionWriterBatch{
+		ops: []*transactionOperation{
+			{
+				txID:     "3",
+				txInsert: txa,
+				nextNonceCB: func(ctx context.Context, signer string) (uint64, error) {
+					return 1 /* below nonce 11111 in the row queried back */, nil
+				},
+				done: make(chan error, 1)},
+			{
+				txID:     "4",
+				txInsert: txb,
+				nextNonceCB: func(ctx context.Context, signer string) (uint64, error) {
+					return 1 /* below nonce 11111 in the row queried back */, nil
+				},
+				done: make(chan error, 1)},
+		},
+	})
+
+	assert.Equal(t, uint64(0x11112), tx1.Nonce.Uint64())
+	assert.Equal(t, uint64(0x11113), tx2.Nonce.Uint64())
+
+	assert.Equal(t, uint64(0x11114), txa.Nonce.Uint64())
+	assert.Equal(t, uint64(0x11115), txb.Nonce.Uint64())
 
 	assert.NoError(t, mdb.ExpectationsWereMet())
 }

--- a/internal/persistence/postgres/transaction_writer_test.go
+++ b/internal/persistence/postgres/transaction_writer_test.go
@@ -174,7 +174,6 @@ func TestExecuteBatchOpsInsertTXFailOverrideNonceBelowTx(t *testing.T) {
 	})
 
 	mdb.ExpectBegin()
-	mdb.ExpectQuery("SELECT.*").WillReturnRows(newTXRow(p))
 	mdb.ExpectExec("INSERT.*").WillReturnResult(driver.ResultNoRows)
 	mdb.ExpectExec("INSERT.*").WillReturnResult(driver.ResultNoRows)
 	mdb.ExpectCommit()


### PR DESCRIPTION
There is a problem when two different batches of transaction inserts happen in parallel, one of them will read the incorrect nonce back from the DB + the nonce callback when the cached nonce expires. 

The fix in the PR is to check the expired cached nonce first to avoid pending transactions that have clashing nonces between them.