### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# FireFly transaction manager maintainers
 * @hyperledger/firefly-transaction-manager-maintainers
-
-# FireFly Documentation Maintainers
-/docs @peterbroadhurst @nguyer @awrichar @nickgaski

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# FireFly Core Maintainers
-* @peterbroadhurst @nguyer @awrichar
+# FireFly transaction manager maintainers
+* @hyperledger/firefly-transaction-manager-maintainers
 
 # FireFly Documentation Maintainers
 /docs @peterbroadhurst @nguyer @awrichar @nickgaski

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,4 +1,4 @@
-# Maintainers
+# firefly-transaction-manager-maintainers
 
 The following is the list of current maintainers this repo:
 
@@ -7,46 +7,8 @@ The following is the list of current maintainers this repo:
 | Peter Broadhurst  | peterbroadhurst | peter.broadhurst@kaleido.io  | peterbroadhurst   |
 | Nicko Guyer       | nguyer          | nicko.guyer@kaleido.io       | nguyer            |
 | Andrew Richardson | awrichar        | andrew.richardson@kaleido.io | Andrew.Richardson |
-
+| Chengxuan Xing    | Chengxuan       | chengxuan.xing@kaleido.io    | chengxuanxing     |
 
 This list is to be kept up to date as maintainers are added or removed.
 
-# Expectations of Maintainers
-
-Maintainers are expected to regularly:
-
-- Make contributions to FireFly code repositories including code or documentation
-- Review pull requests
-- Investigate open GitHub issues
-- Participate in Community Calls
-
-# Becoming a Maintainer
-
-The FireFly Project welcomes and encourages people to become maintainers of the project if they are interested and meet the following criteria:
-
-## Criteria for becoming a member
-
-- Expressed interest and commitment to meet the expectations of a maintainer for at least 6 months
-- A consistent track record of contributions to FireFly code repositories which could be:
-  - Enhancements
-  - Bug fixes
-  - Tests
-  - Documentation
-- A consistent track record of helpful code reviews on FireFly code repositories
-- Regular participation in Community Calls
-- A demonstrated interest and aptitude in thought leadership within the FireFly Project
-- Sponsorship from an existing maintainer
-
-There is no specific quantity of contributions or pull requests, or a specific time period over which the candidate must prove their track record. This will be left up to the discretion of the existing maintainers.
-
-## Process for becoming a maintainer
-
-Once the above criteria have been met, the sponsoring maintainer shall propose the addition of the new maintainer at a public Community Call. Existing maintainers shall vote at the next public Community Call whether the new maintainer should be added or not. Proxy votes may be submitted via email _before_ the meeting. A simple majority of the existing maintainers is required for the vote to pass.
-
-## Maintainer resignation
-
-While maintainers are expected in good faith to be committed to the project for a significant period of time, they are under no binding obligation to do so. Maintainers may resign at any time for any reason. If a maintainer wishes to resign they shall open a pull request to update the maintainers list removing themselves from the list.
-
-## Maintainer inactivity
-
-If a maintainer has remained inactive (not meeting the expectations of a maintainer) for a period of time (at least several months), an email should be sent to that maintainer noting their inactivity and asking if they still wish to be a maintainer. If they continue to be inactive after being notified via email, an existing maintainer may propose to remove the inactive maintainer at a public Community Call. Existing maintainers shall vote at the next public Community Call whether the inactive maintainer should be removed or not. Proxy votes may be submitted via email _before_ the meeting. A simple majority of the existing maintainers is required for the vote to pass.
+For the full list of maintainers across all repos, the expectations of a maintainer and the process for becoming a maintainer, please see the [FireFly Maintainers page on the Hyperledger Wiki](https://wiki.hyperledger.org/display/FIR/Maintainers).


### PR DESCRIPTION
Update code owners file to use the github team


@nguyer Not sure what to do with the Doc maintainers, there isn't a github team for them.

<img width="1167" alt="image" src="https://github.com/hyperledger/firefly-transaction-manager/assets/5425125/472e5080-8c09-4687-820c-0802ac977b43">

@nickgaski also lost access to the repo.