### PR TITLE
Start debug server before we start processing

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,8 +28,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.ORG_PAT }}
-          submodules: recursive
 
       - name: Fetch history # See https://github.com/actions/checkout/issues/477
         run: |-

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,6 +28,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.ORG_PAT }}
+          submodules: recursive
 
       - name: Fetch history # See https://github.com/actions/checkout/issues/477
         run: |-

--- a/config.md
+++ b/config.md
@@ -72,7 +72,36 @@
 
 |Key|Description|Type|Default Value|
 |---|-----------|----|-------------|
-|port|An HTTP port on which to enable the go debugger|`int`|`-1`
+|address|Listener address|`int`|`127.0.0.1`
+|enabled|Whether the debug HTTP endpoint is enabled|`boolean`|`true`
+|port|An HTTP port on which to enable the go debugger|`int`|`0`
+|publicURL|Externally available URL for the HTTP endpoint|`string`|`<nil>`
+|readTimeout|HTTP server read timeout|[`time.Duration`](https://pkg.go.dev/time#Duration)|`15s`
+|shutdownTimeout|HTTP server shutdown timeout|[`time.Duration`](https://pkg.go.dev/time#Duration)|`10s`
+|writeTimeout|HTTP server write timeout|[`time.Duration`](https://pkg.go.dev/time#Duration)|`15s`
+
+## debug.auth
+
+|Key|Description|Type|Default Value|
+|---|-----------|----|-------------|
+|type|The auth plugin to use for server side authentication of requests|`string`|`<nil>`
+
+## debug.auth.basic
+
+|Key|Description|Type|Default Value|
+|---|-----------|----|-------------|
+|passwordfile|The path to a .htpasswd file to use for authenticating requests. Passwords should be hashed with bcrypt.|`string`|`<nil>`
+
+## debug.tls
+
+|Key|Description|Type|Default Value|
+|---|-----------|----|-------------|
+|caFile|The path to the CA file for TLS on this API|`string`|`<nil>`
+|certFile|The path to the certificate file for TLS on this API|`string`|`<nil>`
+|clientAuth|Enables or disables client auth for TLS on this API|`string`|`<nil>`
+|enabled|Enables or disables TLS on this API|`boolean`|`false`
+|keyFile|The path to the private key file for TLS on this API|`string`|`<nil>`
+|requiredDNAttributes|A set of required subject DN attributes. Each entry is a regular expression, and the subject certificate must have a matching attribute of the specified type (CN, C, O, OU, ST, L, STREET, POSTALCODE, SERIALNUMBER are valid attributes)|`map[string]string`|`<nil>`
 
 ## eventstreams
 

--- a/internal/tmconfig/tmconfig.go
+++ b/internal/tmconfig/tmconfig.go
@@ -55,7 +55,6 @@ var (
 	APIMaxRequestTimeout                          = ffc("api.maxRequestTimeout")
 	APIPassthroughHeaders                         = ffc("api.passthroughHeaders")
 	APISimpleQuery                                = ffc("api.simpleQuery")
-	DebugPort                                     = ffc("debug.port")
 	MetricsEnabled                                = ffc("metrics.enabled")
 	MetricsPath                                   = ffc("metrics.path")
 	TransactionsHandlerName                       = ffc("transactions.handler.name")
@@ -74,6 +73,8 @@ var (
 var PersistenceSection config.Section
 
 var PostgresSection config.Section
+
+var DebugConfig config.Section
 
 var APIConfig config.Section
 
@@ -118,7 +119,6 @@ func setDefaults() {
 	viper.SetDefault(string(EventStreamsRetryInitDelay), "250ms")
 	viper.SetDefault(string(EventStreamsRetryMaxDelay), "30s")
 	viper.SetDefault(string(EventStreamsRetryFactor), 2.0)
-	viper.SetDefault(string(DebugPort), -1)
 	viper.SetDefault(string(MetricsEnabled), false)
 	viper.SetDefault(string(MetricsPath), "/metrics")
 
@@ -136,6 +136,9 @@ func setDefaults() {
 
 func Reset() {
 	config.RootConfigReset(setDefaults)
+
+	DebugConfig = config.RootSection("debug")
+	httpserver.InitDebugConfig(DebugConfig)
 
 	APIConfig = config.RootSection("api")
 	httpserver.InitHTTPConfig(APIConfig, 5008)

--- a/pkg/fftm/api.go
+++ b/pkg/fftm/api.go
@@ -18,17 +18,13 @@ package fftm
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"net/http/pprof"
-	"time"
 
 	"github.com/ghodss/yaml"
 	"github.com/gorilla/mux"
 	"github.com/hyperledger/firefly-common/pkg/config"
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
-	"github.com/hyperledger/firefly-common/pkg/log"
 	"github.com/hyperledger/firefly-transaction-manager/internal/tmconfig"
 )
 
@@ -100,23 +96,4 @@ func (m *manager) runAPIServer() {
 
 func (m *manager) runMetricsServer() {
 	m.metricsServer.ServeHTTP(m.ctx)
-}
-
-func (m *manager) runDebugServer() {
-	debugPort := config.GetInt(tmconfig.DebugPort)
-	defer func() {
-		close(m.debugServerDone)
-	}()
-
-	if debugPort >= 0 {
-		r := mux.NewRouter()
-		r.PathPrefix("/debug/pprof/cmdline").HandlerFunc(pprof.Cmdline)
-		r.PathPrefix("/debug/pprof/profile").HandlerFunc(pprof.Profile)
-		r.PathPrefix("/debug/pprof/symbol").HandlerFunc(pprof.Symbol)
-		r.PathPrefix("/debug/pprof/trace").HandlerFunc(pprof.Trace)
-		r.PathPrefix("/debug/pprof/").HandlerFunc(pprof.Index)
-		m.debugServer = &http.Server{Addr: fmt.Sprintf("localhost:%d", debugPort), Handler: r, ReadHeaderTimeout: 30 * time.Second}
-		log.L(m.ctx).Debugf("Debug HTTP endpoint listening on localhost:%d", debugPort)
-		_ = m.debugServer.ListenAndServe()
-	}
 }

--- a/pkg/fftm/api_test.go
+++ b/pkg/fftm/api_test.go
@@ -22,10 +22,8 @@ import (
 	"testing"
 
 	"github.com/go-resty/resty/v2"
-	"github.com/hyperledger/firefly-common/pkg/config"
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-transaction-manager/internal/confirmations"
-	"github.com/hyperledger/firefly-transaction-manager/internal/tmconfig"
 	"github.com/hyperledger/firefly-transaction-manager/mocks/confirmationsmocks"
 	"github.com/hyperledger/firefly-transaction-manager/mocks/ffcapimocks"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/apitypes"
@@ -140,67 +138,6 @@ func TestSendTransactionE2E(t *testing.T) {
 	m.Start()
 
 	req := strings.NewReader(sampleSendTX)
-	res, err := resty.New().R().
-		SetBody(req).
-		Post(url)
-	assert.NoError(t, err)
-	assert.Equal(t, 202, res.StatusCode())
-
-	<-txSent
-
-}
-
-func TestDeployTransactionE2EWithDebugServer(t *testing.T) {
-
-	txSent := make(chan struct{})
-
-	url, m, cancel := newTestManager(t)
-	defer cancel()
-
-	mFFC := m.connector.(*ffcapimocks.API)
-
-	mFFC.On("NextNonceForSigner", mock.Anything, mock.MatchedBy(func(nonceReq *ffcapi.NextNonceForSignerRequest) bool {
-		return "0xb480F96c0a3d6E9e9a263e4665a39bFa6c4d01E8" == nonceReq.Signer
-	})).Return(&ffcapi.NextNonceForSignerResponse{
-		Nonce: fftypes.NewFFBigInt(12345),
-	}, ffcapi.ErrorReason(""), nil)
-
-	mFFC.On("DeployContractPrepare", mock.Anything, mock.MatchedBy(func(prepTX *ffcapi.ContractDeployPrepareRequest) bool {
-		return "0xb480F96c0a3d6E9e9a263e4665a39bFa6c4d01E8" == prepTX.From &&
-			`constructor` == prepTX.Definition.JSONObjectArray()[0].GetString("type") &&
-			`"0xfeedbeef"` == prepTX.Contract.String() &&
-			uint64(1000000) == prepTX.Gas.Uint64() &&
-			1 == len(prepTX.Params) &&
-			"4276993775" == prepTX.Params[0].JSONObject().GetString("value") &&
-			"4276993775" == prepTX.Params[0].JSONObject().GetString("value")
-	})).Return(&ffcapi.TransactionPrepareResponse{
-		TransactionData: "RAW_UNSIGNED_BYTES",
-		Gas:             fftypes.NewFFBigInt(2000000), // gas estimate simulation
-	}, ffcapi.ErrorReason(""), nil)
-
-	mFFC.On("TransactionSend", mock.Anything, mock.MatchedBy(func(sendTX *ffcapi.TransactionSendRequest) bool {
-		matches := "0xb480F96c0a3d6E9e9a263e4665a39bFa6c4d01E8" == sendTX.From &&
-			uint64(2000000) == sendTX.Gas.Uint64() &&
-			`223344556677` == sendTX.GasPrice.String() &&
-			"RAW_UNSIGNED_BYTES" == sendTX.TransactionData
-		if matches {
-			// We're at end of job for this test
-			close(txSent)
-		}
-		return matches
-	})).Return(&ffcapi.TransactionSendResponse{
-		TransactionHash: "0x106215b9c0c9372e3f541beff0cdc3cd061a26f69f3808e28fd139a1abc9d345",
-	}, ffcapi.ErrorReason(""), nil)
-
-	mc := m.confirmations.(*confirmationsmocks.Manager)
-	mc.On("Notify", mock.MatchedBy(func(n *confirmations.Notification) bool {
-		return n.NotificationType == confirmations.NewTransaction
-	})).Return(nil)
-
-	config.Set(tmconfig.DebugPort, 0)
-	m.Start()
-
-	req := strings.NewReader(sampleDeployTX)
 	res, err := resty.New().R().
 		SetBody(req).
 		Post(url)

--- a/pkg/txhandler/simple/policyloop.go
+++ b/pkg/txhandler/simple/policyloop.go
@@ -224,7 +224,8 @@ func (sth *simpleTransactionHandler) processPolicyAPIRequests(ctx context.Contex
 
 		switch request.requestType {
 		case ActionDelete, ActionSuspend, ActionResume:
-			if err := sth.execPolicy(ctx, pending, &request.requestType); err != nil {
+			reqType := request.requestType
+			if err := sth.execPolicy(ctx, pending, &reqType); err != nil {
 				request.response <- policyEngineAPIResponse{err: err}
 			} else {
 				res := policyEngineAPIResponse{tx: pending.mtx, status: http.StatusAccepted}


### PR DESCRIPTION
Notices when debugging an issue, that even though a debug listener was configured, there wasn't one running. Turns out the runtime was hitting a problem establishing its event streams, before starting the debug server.

This PR proposes:
- Starting the debug server earlier
- Using the standard `httpserver` config structure and go routine