### PR TITLE
Enhance logging on event dispatch, and resolve edge case panic

### DIFF
--- a/internal/events/eventstream_test.go
+++ b/internal/events/eventstream_test.go
@@ -1635,7 +1635,7 @@ func TestEventLoopIgnoreBadEvent(t *testing.T) {
 	es.processNewEvent(context.Background(), &ffcapi.ListenerEvent{})
 }
 
-func TestSkipEventsBehindCheckpoint(t *testing.T) {
+func TestSkipEventsBehindCheckpointAndUnknownListener(t *testing.T) {
 
 	es := newTestEventStream(t, `{
 		"name": "ut_stream"
@@ -1679,6 +1679,10 @@ func TestSkipEventsBehindCheckpoint(t *testing.T) {
 	es.batchChannel <- &ffcapi.ListenerEvent{
 		Checkpoint: &utCheckpointType{SomeSequenceNumber: 2000}, // on checkpoint - redelivery
 		Event:      &ffcapi.Event{ID: ffcapi.EventID{ListenerID: listenerID, BlockNumber: 2000}},
+	}
+	es.batchChannel <- &ffcapi.ListenerEvent{
+		Checkpoint: &utCheckpointType{SomeSequenceNumber: 2001}, // this is for a listener that no longer exists on the ES
+		Event:      &ffcapi.Event{ID: ffcapi.EventID{ListenerID: fftypes.NewUUID(), BlockNumber: 2001}},
 	}
 	es.batchChannel <- &ffcapi.ListenerEvent{
 		Checkpoint: &utCheckpointType{SomeSequenceNumber: 2001}, // this is a new event


### PR DESCRIPTION
Couple of small logging enhancements that would have helped me while investigating a set of logs.

Also addresses a panic with a `nil` `batch` object that I found through adding the Unit Test for my new log, which would happen if we did either of....
- The else to this block (which I've now added a log to):
    https://github.com/hyperledger/firefly-transaction-manager/blob/dcc8484eb3c6f1b6e22d649b74e0f2c29c29c83a/internal/events/eventstream.go#L710
- This `continue`:
    https://github.com/hyperledger/firefly-transaction-manager/blob/dcc8484eb3c6f1b6e22d649b74e0f2c29c29c83a/internal/events/eventstream.go#L720