### PR TITLE
update document to reflect supported persistence db types

### DIFF
--- a/config.md
+++ b/config.md
@@ -201,7 +201,7 @@
 
 |Key|Description|Type|Default Value|
 |---|-----------|----|-------------|
-|type|The type of persistence to use|Only 'leveldb' currently supported|`leveldb`
+|type|The type of persistence to use|`leveldb`, `postgres`(supports rich query)|`leveldb`
 
 ## persistence.leveldb
 

--- a/internal/tmmsgs/en_config_descriptions.go
+++ b/internal/tmmsgs/en_config_descriptions.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/tmmsgs/en_config_descriptions.go
+++ b/internal/tmmsgs/en_config_descriptions.go
@@ -94,7 +94,7 @@ var (
 	ConfigEventStreamsRetryMaxDelay                     = ffc("config.eventstreams.retry.maxDelay", "Maximum delay between retries", i18n.TimeDurationType)
 	ConfigEventStreamsRetryFactor                       = ffc("config.eventstreams.retry.factor", "Factor to increase the delay by, between each retry", i18n.FloatType)
 
-	ConfigPersistenceType              = ffc("config.persistence.type", "The type of persistence to use", "Only 'leveldb' currently supported")
+	ConfigPersistenceType              = ffc("config.persistence.type", "The type of persistence to use", "`leveldb`, `postgres`(supports rich query)")
 	ConfigPersistenceLevelDBPath       = ffc("config.persistence.leveldb.path", "The path for the LevelDB persistence directory", i18n.StringType)
 	ConfigPersistenceLevelDBMaxHandles = ffc("config.persistence.leveldb.maxHandles", "The maximum number of cached file handles LevelDB should keep open", i18n.IntType)
 	ConfigPersistenceLevelDBSyncWrites = ffc("config.persistence.leveldb.syncWrites", "Whether to synchronously perform writes to the storage", i18n.BooleanType)


### PR DESCRIPTION
Correct the description of persistence.type and add a note to indicate postgres supports [rich query](https://github.com/kaleido-io/firefly-transaction-manager/blob/15ccd1fea0b4aaaf8ec50d52e6221d2af5dc65d2/pkg/txhandler/txhandler.go#L57).

