### PR TITLE
Fix propagation of `blockNumber` to EVMConnect (and batch logging tweak)

### DIFF
--- a/pkg/apitypes/query_request.go
+++ b/pkg/apitypes/query_request.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -24,6 +24,7 @@ import (
 type QueryRequest struct {
 	Headers RequestHeaders `json:"headers"`
 	ffcapi.TransactionInput
+	BlockNumber *string `json:"blockNumber,omitempty"`
 }
 
 // QueryResponse is the response payload for a query

--- a/pkg/ffcapi/method_call.go
+++ b/pkg/ffcapi/method_call.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -28,7 +28,7 @@ import (
 // detected by the back-end connector.
 type QueryInvokeRequest struct {
 	TransactionInput
-	BlockNumber *fftypes.FFBigInt `json:"blockNumber,omitempty"`
+	BlockNumber *string `json:"blockNumber,omitempty"`
 }
 
 type QueryInvokeResponse struct {

--- a/pkg/fftm/route__root_command.go
+++ b/pkg/fftm/route__root_command.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -101,6 +101,7 @@ var postRootCommand = func(m *manager) *ffapi.Route {
 				}
 				res, _, err := m.connector.QueryInvoke(r.Req.Context(), &ffcapi.QueryInvokeRequest{
 					TransactionInput: tReq.TransactionInput,
+					BlockNumber:      tReq.BlockNumber,
 				})
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
- We weren't passing `blockNumber` down
- We were assuming on the internal struct it had to be a number, where FFTM should not be opinionated
   - Noting that for EVM it can be `"latest"`