### PR TITLE
adding index for status field

### DIFF
--- a/db/migrations/postgres/000009_add_transactions_status_index.down.sql
+++ b/db/migrations/postgres/000009_add_transactions_status_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS transactions_status;

--- a/db/migrations/postgres/000009_add_transactions_status_index.up.sql
+++ b/db/migrations/postgres/000009_add_transactions_status_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX transactions_status ON transactions(status);


### PR DESCRIPTION
Without an index for the status field, the polling cycle will look up more and more transactions to find "Pending" ones, which causing the performance to decrease:

<img width="2491" alt="image" src="https://github.com/hyperledger/firefly-transaction-manager/assets/5425125/109d9faf-20fe-4ede-bf62-4ddf8faec0c9">
