### PR TITLE
fix null pointer when reading inflight queue

### DIFF
--- a/pkg/txhandler/simple/policyloop.go
+++ b/pkg/txhandler/simple/policyloop.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -206,7 +206,7 @@ func (sth *simpleTransactionHandler) processPolicyAPIRequests(ctx context.Contex
 		var pending *pendingState
 		// If this transaction is in-flight, we use that record
 		for _, inflight := range sth.inflight {
-			if inflight.mtx.ID == request.txID {
+			if inflight != nil && inflight.mtx != nil && inflight.mtx.ID == request.txID {
 				pending = inflight
 				break
 			}
@@ -483,7 +483,7 @@ func (sth *simpleTransactionHandler) HandleTransactionConfirmations(ctx context.
 	// Will be picked up on the next policy loop cycle
 	var pending *pendingState
 	for _, p := range sth.inflight {
-		if p.mtx.ID == txID {
+		if p != nil && p.mtx != nil && p.mtx.ID == txID {
 			pending = p
 			break
 		}
@@ -505,7 +505,7 @@ func (sth *simpleTransactionHandler) HandleTransactionConfirmations(ctx context.
 func (sth *simpleTransactionHandler) HandleTransactionReceiptReceived(ctx context.Context, txID string, receipt *ffcapi.TransactionReceiptResponse) (err error) {
 	var pending *pendingState
 	for _, p := range sth.inflight {
-		if p.mtx.ID == txID {
+		if p != nil && p.mtx != nil && p.mtx.ID == txID {
 			pending = p
 			break
 		}


### PR DESCRIPTION
The inflight queue is manipulated by the policy loop. So there is a chance the transactions get cleaned up from the map when other functions are reading it, thus causing the nil pointer exception.

We didn't want to introduce a lock for this as that would slow down the processing of the main policy loop. Therefore, extra checks are added to avoid the exception instead.