### PR TITLE
fix: race condition when reading and writing to inflight queue

### DIFF
--- a/pkg/txhandler/simple/policyloop.go
+++ b/pkg/txhandler/simple/policyloop.go
@@ -327,7 +327,7 @@ func (sth *simpleTransactionHandler) execPolicy(baseCtx context.Context, pending
 	completed := false
 	switch {
 	case ctx.Confirmed && ctx.SyncAction != ActionDelete:
-		log.L(sth.ctx).Debugf("Transaction '%s' confirmed", ctx.TX.ID)
+		log.L(sth.ctx).Tracef("Transaction '%s' confirmed", ctx.TX.ID)
 		completed = true
 		ctx.UpdateType = Update
 		if ctx.Receipt != nil && ctx.Receipt.Success {

--- a/pkg/txhandler/simple/policyloop.go
+++ b/pkg/txhandler/simple/policyloop.go
@@ -120,7 +120,7 @@ func (sth *simpleTransactionHandler) updateInflightSet(ctx context.Context) bool
 
 	// If we are not at maximum, then query if there are more candidates now
 	spaces := sth.maxInFlight - len(sth.inflight)
-	log.L(sth.ctx).Debugf("Number of spaces left '%v'", spaces)
+	log.L(sth.ctx).Tracef("Number of spaces left '%v'", spaces)
 	if spaces > 0 {
 		var after string
 		if len(sth.inflight) > 0 {
@@ -179,7 +179,7 @@ func (sth *simpleTransactionHandler) policyLoopCycle(ctx context.Context, inflig
 	defer sth.inflightRWMux.RUnlock()
 	// Go through executing the policy engine against them
 	for _, pending := range sth.inflight {
-		log.L(ctx).Debugf("Executing policy against tx-id=%v", pending.mtx.ID)
+		log.L(ctx).Tracef("Executing policy against tx-id=%v", pending.mtx.ID)
 		err := sth.execPolicy(ctx, pending, nil)
 		if err != nil {
 			log.L(ctx).Errorf("Failed policy cycle transaction=%s operation=%s: %s", pending.mtx.TransactionHash, pending.mtx.ID, err)
@@ -514,7 +514,7 @@ func (sth *simpleTransactionHandler) HandleTransactionConfirmations(ctx context.
 	return
 }
 func (sth *simpleTransactionHandler) HandleTransactionReceiptReceived(ctx context.Context, txID string, receipt *ffcapi.TransactionReceiptResponse) (err error) {
-	log.L(ctx).Debugf("Handle transaction receipt received %s", txID)
+	log.L(ctx).Tracef("Handle transaction receipt received %s", txID)
 	sth.inflightRWMux.RLock()
 	var pending *pendingState
 	for _, p := range sth.inflight {

--- a/pkg/txhandler/simple/policyloop.go
+++ b/pkg/txhandler/simple/policyloop.go
@@ -110,6 +110,7 @@ func (sth *simpleTransactionHandler) updateInflightSet(ctx context.Context) bool
 	// Run through removing those that are removed
 	for _, p := range oldInflight {
 		if !p.remove {
+			log.L(sth.ctx).Debugf("Removing TX '%s' from inflight", p.mtx.ID)
 			sth.inflight = append(sth.inflight, p)
 		} else {
 			sth.incTransactionOperationCounter(ctx, p.mtx.Namespace(ctx), "removed")
@@ -118,6 +119,7 @@ func (sth *simpleTransactionHandler) updateInflightSet(ctx context.Context) bool
 
 	// If we are not at maximum, then query if there are more candidates now
 	spaces := sth.maxInFlight - len(sth.inflight)
+	log.L(sth.ctx).Debugf("Number of spaces left '%v'", spaces)
 	if spaces > 0 {
 		var after string
 		if len(sth.inflight) > 0 {

--- a/pkg/txhandler/simple/policyloop.go
+++ b/pkg/txhandler/simple/policyloop.go
@@ -155,8 +155,7 @@ func (sth *simpleTransactionHandler) updateInflightSet(ctx context.Context) bool
 		}
 		newLen := len(sth.inflight)
 		if newLen > 0 {
-			log.L(ctx).Debugf("Inflight set updated with %d additional transactions", len(additional))
-			log.L(ctx).Debugf("Inflight set updated len=%d head-id:%s head-seq=%s tail-id:%s tail-seq=%s old-tail=%s", len(sth.inflight), sth.inflight[0].mtx.ID, sth.inflight[0].mtx.SequenceID, sth.inflight[newLen-1].mtx.ID, sth.inflight[newLen-1].mtx.SequenceID, after)
+			log.L(ctx).Debugf("Inflight set updated with %d additional transactions, length is now %d head-id:%s head-seq=%s tail-id:%s tail-seq=%s old-tail=%s", len(additional), len(sth.inflight), sth.inflight[0].mtx.ID, sth.inflight[0].mtx.SequenceID, sth.inflight[newLen-1].mtx.ID, sth.inflight[newLen-1].mtx.SequenceID, after)
 		}
 	}
 	sth.setTransactionInflightQueueMetrics(ctx)
@@ -177,6 +176,7 @@ func (sth *simpleTransactionHandler) policyLoopCycle(ctx context.Context, inflig
 	}
 
 	sth.inflightRWMux.RLock()
+	defer sth.inflightRWMux.RUnlock()
 	// Go through executing the policy engine against them
 	for _, pending := range sth.inflight {
 		log.L(ctx).Debugf("Executing policy against tx-id=%v", pending.mtx.ID)
@@ -185,7 +185,6 @@ func (sth *simpleTransactionHandler) policyLoopCycle(ctx context.Context, inflig
 			log.L(ctx).Errorf("Failed policy cycle transaction=%s operation=%s: %s", pending.mtx.TransactionHash, pending.mtx.ID, err)
 		}
 	}
-	sth.inflightRWMux.RUnlock()
 
 }
 

--- a/pkg/txhandler/simple/policyloop.go
+++ b/pkg/txhandler/simple/policyloop.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -506,6 +506,7 @@ func (sth *simpleTransactionHandler) HandleTransactionConfirmations(ctx context.
 	return
 }
 func (sth *simpleTransactionHandler) HandleTransactionReceiptReceived(ctx context.Context, txID string, receipt *ffcapi.TransactionReceiptResponse) (err error) {
+	log.L(ctx).Debugf("Handle transaction receipt received %s", txID)
 	var pending *pendingState
 	for _, p := range sth.inflight {
 		if p.mtx.ID == txID {

--- a/pkg/txhandler/simple/policyloop.go
+++ b/pkg/txhandler/simple/policyloop.go
@@ -165,7 +165,7 @@ func (sth *simpleTransactionHandler) updateInflightSet(ctx context.Context) bool
 }
 
 func (sth *simpleTransactionHandler) policyLoopCycle(ctx context.Context, inflightStale bool) {
-	log.L(ctx).Debugf("policyLoopCycle triggered inflightStatle=%v", inflightStale)
+	log.L(ctx).Tracef("policyLoopCycle triggered inflightStatle=%v", inflightStale)
 
 	// Process any synchronous commands first - these might not be in our inflight set
 	sth.processPolicyAPIRequests(ctx)

--- a/pkg/txhandler/simple/policyloop.go
+++ b/pkg/txhandler/simple/policyloop.go
@@ -152,7 +152,8 @@ func (sth *simpleTransactionHandler) updateInflightSet(ctx context.Context) bool
 		}
 		newLen := len(sth.inflight)
 		if newLen > 0 {
-			log.L(ctx).Debugf("Inflight set updated len=%d head-seq=%s tail-seq=%s old-tail=%s", len(sth.inflight), sth.inflight[0].mtx.SequenceID, sth.inflight[newLen-1].mtx.SequenceID, after)
+			log.L(ctx).Debugf("Inflight set updated with len=%d additional transactions", len(additional))
+			log.L(ctx).Debugf("Inflight set updated len=%d head-id:%s head-seq=%s tail-id:%s tail-seq=%s old-tail=%s", len(sth.inflight), sth.inflight[0].mtx.ID, sth.inflight[0].mtx.SequenceID, sth.inflight[newLen-1].mtx.ID, sth.inflight[newLen-1].mtx.SequenceID, after)
 		}
 	}
 	sth.setTransactionInflightQueueMetrics(ctx)
@@ -161,6 +162,7 @@ func (sth *simpleTransactionHandler) updateInflightSet(ctx context.Context) bool
 }
 
 func (sth *simpleTransactionHandler) policyLoopCycle(ctx context.Context, inflightStale bool) {
+	log.L(ctx).Debugf("policyLoopCycle triggered inflightStatle=%v", inflightStale)
 
 	// Process any synchronous commands first - these might not be in our inflight set
 	sth.processPolicyAPIRequests(ctx)
@@ -170,9 +172,10 @@ func (sth *simpleTransactionHandler) policyLoopCycle(ctx context.Context, inflig
 			return
 		}
 	}
-	// Go through executing the policy engine against them
 
+	// Go through executing the policy engine against them
 	for _, pending := range sth.inflight {
+		log.L(ctx).Debugf("Executing policy against tx-id=%v", pending.mtx.ID)
 		err := sth.execPolicy(ctx, pending, nil)
 		if err != nil {
 			log.L(ctx).Errorf("Failed policy cycle transaction=%s operation=%s: %s", pending.mtx.TransactionHash, pending.mtx.ID, err)

--- a/pkg/txhandler/simple/policyloop.go
+++ b/pkg/txhandler/simple/policyloop.go
@@ -326,6 +326,7 @@ func (sth *simpleTransactionHandler) execPolicy(baseCtx context.Context, pending
 	completed := false
 	switch {
 	case ctx.Confirmed && ctx.SyncAction != ActionDelete:
+		log.L(sth.ctx).Debugf("Transaction '%s' confirmed", ctx.TX.ID)
 		completed = true
 		ctx.UpdateType = Update
 		if ctx.Receipt != nil && ctx.Receipt.Success {

--- a/pkg/txhandler/simple/simple_transaction_handler.go
+++ b/pkg/txhandler/simple/simple_transaction_handler.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/txhandler/simple/simple_transaction_handler.go
+++ b/pkg/txhandler/simple/simple_transaction_handler.go
@@ -344,8 +344,9 @@ func (sth *simpleTransactionHandler) createManagedTx(ctx context.Context, txID s
 }
 
 func (sth *simpleTransactionHandler) submitTX(ctx *RunContext) (reason ffcapi.ErrorReason, err error) {
-
 	mtx := ctx.TX
+	log.L(ctx).Debugf("Submitting transaction %s at nonce %s / %d", mtx.ID, mtx.TransactionHeaders.From, mtx.Nonce.Int64())
+
 	mtx.GasPrice, err = sth.getGasPrice(ctx, sth.toolkit.Connector)
 	if err != nil {
 		ctx.AddSubStatusAction(apitypes.TxActionRetrieveGasPrice, nil, fftypes.JSONAnyPtr(`{"error":"`+err.Error()+`"}`))

--- a/pkg/txhandler/simple/simple_transaction_handler.go
+++ b/pkg/txhandler/simple/simple_transaction_handler.go
@@ -172,12 +172,12 @@ type simpleTransactionHandler struct {
 	gasOracleQueryValue    *fftypes.JSONAny
 	gasOracleLastQueryTime *fftypes.FFTime
 
-	policyLoopInterval time.Duration
-	policyLoopDone     chan struct{}
-	inflightStale      chan bool
-	inflightUpdate     chan bool
-	mux                sync.Mutex
-	// TODO: We should make this a sync map!
+	policyLoopInterval      time.Duration
+	policyLoopDone          chan struct{}
+	inflightStale           chan bool
+	inflightUpdate          chan bool
+	mux                     sync.RWMutex
+	inflightRWMux           sync.RWMutex
 	inflight                []*pendingState
 	policyEngineAPIRequests []*policyEngineAPIRequest
 	maxInFlight             int
@@ -196,6 +196,7 @@ type pendingState struct {
 	confirmNotify           *fftypes.FFTime
 	remove                  bool
 	subStatus               apitypes.TxSubStatus
+	mux                     sync.Mutex
 }
 
 type simplePolicyInfo struct {

--- a/pkg/txhandler/simple/simple_transaction_handler.go
+++ b/pkg/txhandler/simple/simple_transaction_handler.go
@@ -196,7 +196,9 @@ type pendingState struct {
 	confirmNotify           *fftypes.FFTime
 	remove                  bool
 	subStatus               apitypes.TxSubStatus
-	mux                     sync.Mutex
+	// This mutex only works in a slice when the slice contains a pointer to this struct
+	// appends to a slice copy memory but when storing pointers it does not
+	mux sync.Mutex
 }
 
 type simplePolicyInfo struct {

--- a/pkg/txhandler/simple/simple_transaction_handler.go
+++ b/pkg/txhandler/simple/simple_transaction_handler.go
@@ -349,7 +349,6 @@ func (sth *simpleTransactionHandler) createManagedTx(ctx context.Context, txID s
 
 func (sth *simpleTransactionHandler) submitTX(ctx *RunContext) (reason ffcapi.ErrorReason, err error) {
 	mtx := ctx.TX
-	log.L(ctx).Debugf("Submitting transaction %s at nonce %s / %d", mtx.ID, mtx.TransactionHeaders.From, mtx.Nonce.Int64())
 
 	mtx.GasPrice, err = sth.getGasPrice(ctx, sth.toolkit.Connector)
 	if err != nil {

--- a/pkg/txhandler/simple/simple_transaction_handler.go
+++ b/pkg/txhandler/simple/simple_transaction_handler.go
@@ -172,11 +172,12 @@ type simpleTransactionHandler struct {
 	gasOracleQueryValue    *fftypes.JSONAny
 	gasOracleLastQueryTime *fftypes.FFTime
 
-	policyLoopInterval      time.Duration
-	policyLoopDone          chan struct{}
-	inflightStale           chan bool
-	inflightUpdate          chan bool
-	mux                     sync.Mutex
+	policyLoopInterval time.Duration
+	policyLoopDone     chan struct{}
+	inflightStale      chan bool
+	inflightUpdate     chan bool
+	mux                sync.Mutex
+	// TODO: We should make this a sync map!
 	inflight                []*pendingState
 	policyEngineAPIRequests []*policyEngineAPIRequest
 	maxInFlight             int


### PR DESCRIPTION
The policy loop frequently read and writes from the inflight queue, more specifically:
- It will load new transactions into the queue when it has space in `updateInFlightSet` and remove the ones that have completed.
- Remove transactions from the queue when it gets enough confirmations for that transaction

When loading new transactions, the code will take a copy and override the inflight queue with an empty array. If another thread was reading from such array, most often iterating to find a specific inflight tx it wouldn't find it.

This PR alongside with adding extra logging to help diagnose this sort of issues, adds a read/write mutex for the inflight queue and a mutex for each pendingState to be thread safe. Creates read locks when iterating and reading from the queue, write lock in a single place where we remove or load new transactions in queue and a mutex on the pendingState when we read or modify it.


Draft: as running another performance test for the latest commit