### PR TITLE
Add synced field to HWM response

### DIFF
--- a/pkg/ffcapi/event_listener_hwm.go
+++ b/pkg/ffcapi/event_listener_hwm.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ffcapi/event_listener_hwm.go
+++ b/pkg/ffcapi/event_listener_hwm.go
@@ -27,6 +27,10 @@ type EventListenerHWMRequest struct {
 
 type EventListenerHWMResponse struct {
 	Checkpoint EventListenerCheckpoint `json:"checkpoint"`
-	Catchup    bool                    `json:"catchup,omitempty"` // informational only - informs an operator that the stream is catching up
-	Synced     bool                    `json:"synced,omitempty"`  // derived from the distance of the checkpoint block from chain head
+	// Catchup and Synced capture how up-to-date the listener is vs the chain head
+	// If it is a long way back, it will enter a catchup mode
+	// If it is a short way back, it will be considered out-of-sync
+	// If Catchup is true, Synced must be false
+	Catchup bool `json:"catchup,omitempty"` // informational only - informs an operator that the stream is catching up
+	Synced  bool `json:"synced,omitempty"`  // derived from the distance of the checkpoint block from chain head
 }

--- a/pkg/ffcapi/event_listener_hwm.go
+++ b/pkg/ffcapi/event_listener_hwm.go
@@ -28,4 +28,5 @@ type EventListenerHWMRequest struct {
 type EventListenerHWMResponse struct {
 	Checkpoint EventListenerCheckpoint `json:"checkpoint"`
 	Catchup    bool                    `json:"catchup,omitempty"` // informational only - informs an operator that the stream is catching up
+	Synced     bool                    `json:"synced,omitempty"`  // derived from the distance of the checkpoint block from chain head
 }

--- a/pkg/fftm/route_get_eventstream_listener_test.go
+++ b/pkg/fftm/route_get_eventstream_listener_test.go
@@ -42,7 +42,7 @@ func TestGetEventStreamsListener(t *testing.T) {
 	mfc.On("EventListenerAdd", mock.Anything, mock.Anything).Return(&ffcapi.EventListenerAddResponse{}, ffcapi.ErrorReason(""), nil)
 	mfc.On("EventListenerRemove", mock.Anything, mock.Anything).Return(&ffcapi.EventListenerRemoveResponse{}, ffcapi.ErrorReason(""), nil).Maybe()
 	mfc.On("EventStreamStopped", mock.Anything, mock.Anything).Return(&ffcapi.EventStreamStoppedResponse{}, ffcapi.ErrorReason(""), nil).Maybe()
-	mfc.On("EventListenerHWM", mock.Anything, mock.Anything).Return(&ffcapi.EventListenerHWMResponse{Catchup: true}, ffcapi.ErrorReason(""), nil).Maybe()
+	mfc.On("EventListenerHWM", mock.Anything, mock.Anything).Return(&ffcapi.EventListenerHWMResponse{Catchup: true, Synced: false}, ffcapi.ErrorReason(""), nil).Maybe()
 
 	// Create a stream
 	var es1 apitypes.EventStream
@@ -64,6 +64,7 @@ func TestGetEventStreamsListener(t *testing.T) {
 
 	assert.Equal(t, l1.ID, listener.ID)
 	assert.True(t, listener.Catchup)
+	assert.False(t, listener.Synced)
 
 	mfc.AssertExpectations(t)
 

--- a/pkg/fftm/route_get_subscription_test.go
+++ b/pkg/fftm/route_get_subscription_test.go
@@ -41,7 +41,7 @@ func TestGetSubscription(t *testing.T) {
 	mfc.On("EventListenerAdd", mock.Anything, mock.Anything).Return(&ffcapi.EventListenerAddResponse{}, ffcapi.ErrorReason(""), nil)
 	mfc.On("EventListenerRemove", mock.Anything, mock.Anything).Return(&ffcapi.EventListenerRemoveResponse{}, ffcapi.ErrorReason(""), nil).Maybe()
 	mfc.On("EventStreamStopped", mock.Anything, mock.Anything).Return(&ffcapi.EventStreamStoppedResponse{}, ffcapi.ErrorReason(""), nil).Maybe()
-	mfc.On("EventListenerHWM", mock.Anything, mock.Anything).Return(&ffcapi.EventListenerHWMResponse{Catchup: true}, ffcapi.ErrorReason(""), nil).Maybe()
+	mfc.On("EventListenerHWM", mock.Anything, mock.Anything).Return(&ffcapi.EventListenerHWMResponse{Catchup: true, Synced: false}, ffcapi.ErrorReason(""), nil).Maybe()
 
 	// Create a stream
 	var es1 apitypes.EventStream
@@ -63,6 +63,7 @@ func TestGetSubscription(t *testing.T) {
 
 	assert.Equal(t, l1.ID, listener.ID)
 	assert.True(t, listener.Catchup)
+	assert.False(t, listener.Synced)
 
 	mfc.AssertExpectations(t)
 


### PR DESCRIPTION
Add a synced field to a high water mark response to give connectors a place to record info about whether a listener should be considered in- or out-of-sync