### PR TITLE
fix: deleting listeners from event stream pagination

### DIFF
--- a/pkg/fftm/stream_management.go
+++ b/pkg/fftm/stream_management.go
@@ -32,7 +32,7 @@ import (
 	"github.com/hyperledger/firefly-transaction-manager/pkg/txhandler"
 )
 
-var (
+const (
 	startupPaginationLimit = 25
 )
 

--- a/pkg/fftm/stream_management_test.go
+++ b/pkg/fftm/stream_management_test.go
@@ -186,10 +186,79 @@ func TestDeleteStartedListenerFail(t *testing.T) {
 	mp.On("ListStreamListenersByCreateTime", m.ctx, (*fftypes.UUID)(nil), startupPaginationLimit, txhandler.SortDirectionAscending, esID).Return([]*apitypes.Listener{
 		{ID: lID, StreamID: esID},
 	}, nil)
+	mp.On("ListStreamListenersByCreateTime", m.ctx, lID, startupPaginationLimit, txhandler.SortDirectionAscending, esID).Return([]*apitypes.Listener{}, nil)
 	mp.On("DeleteListener", m.ctx, lID).Return(fmt.Errorf("pop"))
 
 	err := m.deleteAllStreamListeners(m.ctx, esID)
 	assert.Regexp(t, "pop", err)
+
+	mp.AssertExpectations(t)
+}
+
+func TestDeleteStartedListenerWithPaginationFail(t *testing.T) {
+
+	_, m, close := newTestManagerMockPersistence(t)
+	defer close()
+
+	esID := apitypes.NewULID()
+	lID := apitypes.NewULID()
+	secondID := apitypes.NewULID()
+	fmt.Println(lID)
+	fmt.Println(secondID)
+	mp := m.persistence.(*persistencemocks.Persistence)
+	startupPaginationLimit = 2
+	mp.On("ListStreamListenersByCreateTime", m.ctx, (*fftypes.UUID)(nil), startupPaginationLimit, txhandler.SortDirectionAscending, esID).Return(
+		[]*apitypes.Listener{
+			{ID: lID, StreamID: esID},
+			{ID: secondID, StreamID: esID},
+		}, nil).Once()
+	thirdID := apitypes.NewULID()
+	mp.On("ListStreamListenersByCreateTime", m.ctx, secondID, startupPaginationLimit, txhandler.SortDirectionAscending, esID).Return(
+		[]*apitypes.Listener{
+			{ID: thirdID, StreamID: esID},
+		}, fmt.Errorf("pop")).Once()
+	mp.On("DeleteListener", m.ctx, lID).Return(nil)
+
+	err := m.deleteAllStreamListeners(m.ctx, esID)
+	assert.Regexp(t, "pop", err)
+
+	startupPaginationLimit = 25
+
+	mp.AssertExpectations(t)
+}
+
+func TestDeleteStartedListenerWithPagination(t *testing.T) {
+
+	_, m, close := newTestManagerMockPersistence(t)
+	defer close()
+
+	esID := apitypes.NewULID()
+	lID := apitypes.NewULID()
+	secondID := apitypes.NewULID()
+	fmt.Println(lID)
+	fmt.Println(secondID)
+	mp := m.persistence.(*persistencemocks.Persistence)
+	startupPaginationLimit = 2
+	mp.On("ListStreamListenersByCreateTime", m.ctx, (*fftypes.UUID)(nil), startupPaginationLimit, txhandler.SortDirectionAscending, esID).Return(
+		[]*apitypes.Listener{
+			{ID: lID, StreamID: esID},
+			{ID: secondID, StreamID: esID},
+		}, nil).Once()
+	thirdID := apitypes.NewULID()
+	mp.On("ListStreamListenersByCreateTime", m.ctx, secondID, startupPaginationLimit, txhandler.SortDirectionAscending, esID).Return(
+		[]*apitypes.Listener{
+			{ID: thirdID, StreamID: esID},
+		}, nil).Once()
+	mp.On("ListStreamListenersByCreateTime", m.ctx, thirdID, startupPaginationLimit, txhandler.SortDirectionAscending, esID).Return(
+		[]*apitypes.Listener{}, nil).Once()
+	mp.On("DeleteListener", m.ctx, lID).Return(nil)
+	mp.On("DeleteListener", m.ctx, secondID).Return(nil)
+	mp.On("DeleteListener", m.ctx, thirdID).Return(nil)
+
+	err := m.deleteAllStreamListeners(m.ctx, esID)
+	assert.NoError(t, err)
+
+	startupPaginationLimit = 25
 
 	mp.AssertExpectations(t)
 }

--- a/pkg/fftm/stream_management_test.go
+++ b/pkg/fftm/stream_management_test.go
@@ -186,43 +186,10 @@ func TestDeleteStartedListenerFail(t *testing.T) {
 	mp.On("ListStreamListenersByCreateTime", m.ctx, (*fftypes.UUID)(nil), startupPaginationLimit, txhandler.SortDirectionAscending, esID).Return([]*apitypes.Listener{
 		{ID: lID, StreamID: esID},
 	}, nil)
-	mp.On("ListStreamListenersByCreateTime", m.ctx, lID, startupPaginationLimit, txhandler.SortDirectionAscending, esID).Return([]*apitypes.Listener{}, nil)
 	mp.On("DeleteListener", m.ctx, lID).Return(fmt.Errorf("pop"))
 
 	err := m.deleteAllStreamListeners(m.ctx, esID)
 	assert.Regexp(t, "pop", err)
-
-	mp.AssertExpectations(t)
-}
-
-func TestDeleteStartedListenerWithPaginationFail(t *testing.T) {
-
-	_, m, close := newTestManagerMockPersistence(t)
-	defer close()
-
-	esID := apitypes.NewULID()
-	lID := apitypes.NewULID()
-	secondID := apitypes.NewULID()
-	fmt.Println(lID)
-	fmt.Println(secondID)
-	mp := m.persistence.(*persistencemocks.Persistence)
-	startupPaginationLimit = 2
-	mp.On("ListStreamListenersByCreateTime", m.ctx, (*fftypes.UUID)(nil), startupPaginationLimit, txhandler.SortDirectionAscending, esID).Return(
-		[]*apitypes.Listener{
-			{ID: lID, StreamID: esID},
-			{ID: secondID, StreamID: esID},
-		}, nil).Once()
-	thirdID := apitypes.NewULID()
-	mp.On("ListStreamListenersByCreateTime", m.ctx, secondID, startupPaginationLimit, txhandler.SortDirectionAscending, esID).Return(
-		[]*apitypes.Listener{
-			{ID: thirdID, StreamID: esID},
-		}, fmt.Errorf("pop")).Once()
-	mp.On("DeleteListener", m.ctx, lID).Return(nil)
-
-	err := m.deleteAllStreamListeners(m.ctx, esID)
-	assert.Regexp(t, "pop", err)
-
-	startupPaginationLimit = 25
 
 	mp.AssertExpectations(t)
 }
@@ -235,30 +202,25 @@ func TestDeleteStartedListenerWithPagination(t *testing.T) {
 	esID := apitypes.NewULID()
 	lID := apitypes.NewULID()
 	secondID := apitypes.NewULID()
-	fmt.Println(lID)
-	fmt.Println(secondID)
 	mp := m.persistence.(*persistencemocks.Persistence)
-	startupPaginationLimit = 2
 	mp.On("ListStreamListenersByCreateTime", m.ctx, (*fftypes.UUID)(nil), startupPaginationLimit, txhandler.SortDirectionAscending, esID).Return(
 		[]*apitypes.Listener{
 			{ID: lID, StreamID: esID},
 			{ID: secondID, StreamID: esID},
 		}, nil).Once()
 	thirdID := apitypes.NewULID()
-	mp.On("ListStreamListenersByCreateTime", m.ctx, secondID, startupPaginationLimit, txhandler.SortDirectionAscending, esID).Return(
+	mp.On("ListStreamListenersByCreateTime", m.ctx, (*fftypes.UUID)(nil), startupPaginationLimit, txhandler.SortDirectionAscending, esID).Return(
 		[]*apitypes.Listener{
 			{ID: thirdID, StreamID: esID},
 		}, nil).Once()
-	mp.On("ListStreamListenersByCreateTime", m.ctx, thirdID, startupPaginationLimit, txhandler.SortDirectionAscending, esID).Return(
-		[]*apitypes.Listener{}, nil).Once()
+	mp.On("ListStreamListenersByCreateTime", m.ctx, (*fftypes.UUID)(nil), startupPaginationLimit, txhandler.SortDirectionAscending, esID).Return(
+		[]*apitypes.Listener{}, nil)
 	mp.On("DeleteListener", m.ctx, lID).Return(nil)
 	mp.On("DeleteListener", m.ctx, secondID).Return(nil)
 	mp.On("DeleteListener", m.ctx, thirdID).Return(nil)
 
 	err := m.deleteAllStreamListeners(m.ctx, esID)
 	assert.NoError(t, err)
-
-	startupPaginationLimit = 25
 
 	mp.AssertExpectations(t)
 }


### PR DESCRIPTION
When deleting an event stream that has more listeners that the default pagination limit, it was failing due to incorrect logic of deleting the listener before using it as "offset" to query the next set of listeners to delete.


This PR fixes this by querying the next set before deleting the last one.