### PR TITLE
Add an option to avoid schedule receipt check immediately

### DIFF
--- a/config.md
+++ b/config.md
@@ -44,6 +44,7 @@
 |Key|Description|Type|Default Value|
 |---|-----------|----|-------------|
 |blockQueueLength|Internal queue length for notifying the confirmations manager of new blocks|`int`|`50`
+|fetchReceiptUponEntry|Fetch receipt of new transactions immediately when they are added to the internal queue. When set to false, fetch will only happen when a new block is received or the transaction has been queue for more than the stale receipt timeout|`boolean`|`true`
 |notificationQueueLength|Internal queue length for notifying the confirmations manager of new transactions/events|`int`|`50`
 |receiptWorkers|Number of workers to use to query in parallel for receipts|`int`|`10`
 |required|Number of confirmations required to consider a transaction/event final|`int`|`20`

--- a/config.md
+++ b/config.md
@@ -44,7 +44,7 @@
 |Key|Description|Type|Default Value|
 |---|-----------|----|-------------|
 |blockQueueLength|Internal queue length for notifying the confirmations manager of new blocks|`int`|`50`
-|fetchReceiptUponEntry|Fetch receipt of new transactions immediately when they are added to the internal queue. When set to false, fetch will only happen when a new block is received or the transaction has been queue for more than the stale receipt timeout|`boolean`|`true`
+|fetchReceiptUponEntry|Fetch receipt of new transactions immediately when they are added to the internal queue. When set to false, fetch will only happen when a new block is received or the transaction has been queue for more than the stale receipt timeout|`boolean`|`false`
 |notificationQueueLength|Internal queue length for notifying the confirmations manager of new transactions/events|`int`|`50`
 |receiptWorkers|Number of workers to use to query in parallel for receipts|`int`|`10`
 |required|Number of confirmations required to consider a transaction/event final|`int`|`20`

--- a/internal/confirmations/confirmations_test.go
+++ b/internal/confirmations/confirmations_test.go
@@ -1185,7 +1185,7 @@ func TestCheckReceiptWalkFail(t *testing.T) {
 	bcm.dispatchReceipt(pending, receipt, blocks)
 }
 
-func TestStaleReceiptCheck(t *testing.T) {
+func TestScheduleReceiptCheck(t *testing.T) {
 
 	bcm, _ := newTestBlockConfirmationManager(t, false)
 	emm := &metricsmocks.EventMetricsEmitter{}
@@ -1197,17 +1197,24 @@ func TestStaleReceiptCheck(t *testing.T) {
 	emm.On("RecordConfirmationMetrics", mock.Anything, mock.Anything).Maybe()
 	bcm.receiptChecker = newReceiptChecker(bcm, 0, emm)
 
-	txHash := "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
-	pending := &pendingItem{
+	pendingStale := &pendingItem{ // stale
 		pType:                pendingTypeTransaction,
 		lastReceiptCheck:     time.Now().Add(-1 * time.Hour),
-		transactionHash:      txHash,
+		transactionHash:      "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
 		scheduledAtLeastOnce: true,
 	}
-	bcm.pending[pending.getKey()] = pending
-	bcm.scheduleReceiptChecks(false)
 
-	assert.Equal(t, bcm.receiptChecker.entries.Len(), 1)
+	pendingNotScheduled := &pendingItem{ // not scheduled
+		pType:                pendingTypeTransaction,
+		lastReceiptCheck:     time.Now().Add(-1 * time.Hour),
+		transactionHash:      "0x531e219d98d81dc9f9a14811ac537479f5d77a74bdba47629bfbebe2d7663ce7",
+		scheduledAtLeastOnce: false,
+	}
+	bcm.pending[pendingStale.getKey()] = pendingStale
+	bcm.pending[pendingNotScheduled.getKey()] = pendingNotScheduled
+	bcm.scheduleReceiptChecks(true)
+
+	assert.Equal(t, bcm.receiptChecker.entries.Len(), 2)
 
 }
 

--- a/internal/confirmations/confirmations_test.go
+++ b/internal/confirmations/confirmations_test.go
@@ -462,6 +462,7 @@ func TestBlockConfirmationManagerE2EForkReNotifyConfirmations(t *testing.T) {
 
 func TestBlockConfirmationManagerE2ETransactionMovedFork(t *testing.T) {
 	bcm, mca := newTestBlockConfirmationManager(t, true)
+	bcm.fetchReceiptUponEntry = true // mark fetch receipt upon entry to do a fetch receipt before any blocks were retrieved
 
 	confirmed := make(chan *apitypes.ConfirmationsNotification, 1)
 	receiptReceived := make(chan *ffcapi.TransactionReceiptResponse, 1)
@@ -643,7 +644,7 @@ func TestBlockConfirmationManagerE2ETransactionMovedFork(t *testing.T) {
 	bcm.Stop()
 
 	mca.AssertExpectations(t)
-
+	// false
 }
 
 func TestBlockConfirmationManagerE2EHistoricalEvent(t *testing.T) {

--- a/internal/confirmations/confirmations_test.go
+++ b/internal/confirmations/confirmations_test.go
@@ -1199,12 +1199,13 @@ func TestStaleReceiptCheck(t *testing.T) {
 
 	txHash := "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
 	pending := &pendingItem{
-		pType:            pendingTypeTransaction,
-		lastReceiptCheck: time.Now().Add(-1 * time.Hour),
-		transactionHash:  txHash,
+		pType:                pendingTypeTransaction,
+		lastReceiptCheck:     time.Now().Add(-1 * time.Hour),
+		transactionHash:      txHash,
+		scheduledAtLeastOnce: true,
 	}
 	bcm.pending[pending.getKey()] = pending
-	bcm.staleReceiptCheck()
+	bcm.scheduleReceiptChecks(false)
 
 	assert.Equal(t, bcm.receiptChecker.entries.Len(), 1)
 

--- a/internal/confirmations/receipt_checker.go
+++ b/internal/confirmations/receipt_checker.go
@@ -149,6 +149,7 @@ func (rc *receiptChecker) schedule(pending *pendingItem, suspectedTimeout bool) 
 		return
 	}
 	pending.queuedStale = rc.entries.PushBack(pending)
+	pending.scheduledAtLeastOnce = true
 	rc.cond.Signal()
 	rc.cond.L.Unlock()
 	// Log (outside the lock as it's a contended one)

--- a/internal/confirmations/receipt_checker_test.go
+++ b/internal/confirmations/receipt_checker_test.go
@@ -130,5 +130,4 @@ func TestCheckReceiptDoubleQueueProtection(t *testing.T) {
 	// to a worker, and when it's successfully executed (or put back on the end of the list)
 	bcm.receiptChecker.schedule(pending, false)
 	assert.Zero(t, bcm.receiptChecker.entries.Len())
-
 }

--- a/internal/tmconfig/tmconfig.go
+++ b/internal/tmconfig/tmconfig.go
@@ -99,7 +99,7 @@ func setDefaults() {
 	viper.SetDefault(string(ConfirmationsRetryInitDelay), "100ms")
 	viper.SetDefault(string(ConfirmationsRetryMaxDelay), "15s")
 	viper.SetDefault(string(ConfirmationsRetryFactor), 2.0)
-	viper.SetDefault(string(ConfirmationsFetchReceiptUponEntry), true)
+	viper.SetDefault(string(ConfirmationsFetchReceiptUponEntry), false)
 
 	viper.SetDefault(string(EventStreamsDefaultsBatchSize), 50)
 	viper.SetDefault(string(EventStreamsDefaultsBatchTimeout), "5s")

--- a/internal/tmconfig/tmconfig.go
+++ b/internal/tmconfig/tmconfig.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -30,6 +30,7 @@ var (
 	ConfirmationsRequired                         = ffc("confirmations.required")
 	ConfirmationsBlockQueueLength                 = ffc("confirmations.blockQueueLength")
 	ConfirmationsStaleReceiptTimeout              = ffc("confirmations.staleReceiptTimeout")
+	ConfirmationsFetchReceiptUponEntry            = ffc("confirmations.fetchReceiptUponEntry")
 	ConfirmationsNotificationQueueLength          = ffc("confirmations.notificationQueueLength")
 	ConfirmationsReceiptWorkers                   = ffc("confirmations.receiptWorkers")
 	ConfirmationsRetryInitDelay                   = ffc("confirmations.retry.initialDelay")
@@ -98,6 +99,7 @@ func setDefaults() {
 	viper.SetDefault(string(ConfirmationsRetryInitDelay), "100ms")
 	viper.SetDefault(string(ConfirmationsRetryMaxDelay), "15s")
 	viper.SetDefault(string(ConfirmationsRetryFactor), 2.0)
+	viper.SetDefault(string(ConfirmationsFetchReceiptUponEntry), true)
 
 	viper.SetDefault(string(EventStreamsDefaultsBatchSize), 50)
 	viper.SetDefault(string(EventStreamsDefaultsBatchTimeout), "5s")

--- a/internal/tmmsgs/en_config_descriptions.go
+++ b/internal/tmmsgs/en_config_descriptions.go
@@ -45,6 +45,7 @@ var (
 	ConfigConfirmationsNotificationsQueueLength = ffc("config.confirmations.notificationQueueLength", "Internal queue length for notifying the confirmations manager of new transactions/events", i18n.IntType)
 	ConfigConfirmationsRequired                 = ffc("config.confirmations.required", "Number of confirmations required to consider a transaction/event final", i18n.IntType)
 	ConfigConfirmationsStaleReceiptTimeout      = ffc("config.confirmations.staleReceiptTimeout", "Duration after which to force a receipt check for a pending transaction", i18n.TimeDurationType)
+	ConfigConfirmationsFetchReceiptUponEntry    = ffc("config.confirmations.fetchReceiptUponEntry", "Fetch receipt of new transactions immediately when they are added to the internal queue. When set to false, fetch will only happen when a new block is received or the transaction has been queue for more than the stale receipt timeout", i18n.BooleanType)
 	ConfigConfirmationsReceiptWorkers           = ffc("config.confirmations.receiptWorkers", "Number of workers to use to query in parallel for receipts", i18n.IntType)
 
 	ConfigTransactionsNonceStateTimeout = ffc("config.transactions.nonceStateTimeout", "How old the most recently submitted transaction record in our local state needs to be, before we make a request to the node to query the next nonce for a signing address", i18n.TimeDurationType)


### PR DESCRIPTION
Currently, when a new transaction is registered for receipt, the confirmation manager schedules the check immediately. This caused two problems:
- If the transactions are new, the first receipt check is almost guaranteed to be wasted as the transaction wouldn't have been mined into a block yet.
- if the receipt was retrieve, duplicate receipt checks are possible due to a racing condition with the logic that schedules transaction receipt in processBlock.  https://github.com/hyperledger/firefly-transaction-manager/commit/8e15e84fc6e9f792f7c1e20124a120309f159658 demonstrates a naive fix from a different angle, but it won't work with forking situation.

The proposed PR delay the first fetch to when a new block is received or when the transaction has queued for longer than stale timeout. The behavior is put under a new configuration.