### PR TITLE
Do not keep dispatching after block listener falls behind

### DIFF
--- a/internal/confirmations/confirmed_block_listener.go
+++ b/internal/confirmations/confirmed_block_listener.go
@@ -194,12 +194,12 @@ func (cbl *confirmedBlockListener) processBlockNotification(block *apitypes.Bloc
 	var dispatchHead *apitypes.BlockInfo
 	if len(cbl.newHeadToAdd) > 0 {
 		// we've snuck in multiple notifications while the dispatcher is busy... don't add indefinitely to this list
-		if len(cbl.newHeadToAdd) > 10 /* not considered worth adding/explaining a tuning property for this */ {
+		if len(cbl.newHeadToAdd) >= 10 /* not considered worth adding/explaining a tuning property for this */ {
 			log.L(cbl.ctx).Infof("Block listener fell behind head of chain")
-			cbl.newHeadToAdd = nil
-		} else {
-			dispatchHead = cbl.newHeadToAdd[len(cbl.newHeadToAdd)-1]
+			// Nothing more we can do in this function until it catches up - we just have to discard the notification
+			return
 		}
+		dispatchHead = cbl.newHeadToAdd[len(cbl.newHeadToAdd)-1]
 	}
 	if dispatchHead == nil && len(cbl.blocksSinceCheckpoint) > 0 {
 		dispatchHead = cbl.blocksSinceCheckpoint[len(cbl.blocksSinceCheckpoint)-1]


### PR DESCRIPTION
Fixes #127 

When I spent time breaking down the test to remove timing conditions, I found I was driving the logic below the new `return` I added in invalid ways. So the `return` felt much better to leave the existing queue in flight, and then the dispatcher will still fall back to `getBlockByNumber`