### PR TITLE
Provide implementations access to TransactionHandler

### DIFF
--- a/pkg/fftm/manager.go
+++ b/pkg/fftm/manager.go
@@ -43,6 +43,7 @@ import (
 type Manager interface {
 	Start() error
 	Close()
+	TransactionHandler() txhandler.TransactionHandler
 }
 
 type manager struct {
@@ -199,6 +200,10 @@ func (m *manager) Start() error {
 	}
 	m.started = true
 	return nil
+}
+
+func (m *manager) TransactionHandler() txhandler.TransactionHandler {
+	return m.txHandler
 }
 
 func (m *manager) Close() {

--- a/pkg/fftm/manager.go
+++ b/pkg/fftm/manager.go
@@ -35,6 +35,7 @@ import (
 	"github.com/hyperledger/firefly-transaction-manager/internal/tmconfig"
 	"github.com/hyperledger/firefly-transaction-manager/internal/tmmsgs"
 	"github.com/hyperledger/firefly-transaction-manager/internal/ws"
+	"github.com/hyperledger/firefly-transaction-manager/pkg/apitypes"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/txhandler"
 	txRegistry "github.com/hyperledger/firefly-transaction-manager/pkg/txhandler/registry"
@@ -43,6 +44,8 @@ import (
 type Manager interface {
 	Start() error
 	Close()
+
+	GetTransactionByIDWithStatus(ctx context.Context, txID string, withHistory bool) (transaction *apitypes.TXWithStatus, err error)
 	TransactionHandler() txhandler.TransactionHandler
 }
 

--- a/pkg/fftm/manager_test.go
+++ b/pkg/fftm/manager_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 const testManagerName = "unittest"
@@ -93,6 +94,8 @@ func newTestManager(t *testing.T) (string, *manager, func()) {
 	mcm := &confirmationsmocks.Manager{}
 	mcm.On("Start").Return().Maybe()
 	m.confirmations = mcm
+
+	require.NotNil(t, m.TransactionHandler())
 
 	return url,
 		m,

--- a/pkg/fftm/route_get_transaction.go
+++ b/pkg/fftm/route_get_transaction.go
@@ -41,7 +41,7 @@ var getTransaction = func(m *manager) *ffapi.Route {
 		JSONOutputValue: func() interface{} { return &apitypes.TXWithStatus{} },
 		JSONOutputCodes: []int{http.StatusOK},
 		JSONHandler: func(r *ffapi.APIRequest) (output interface{}, err error) {
-			return m.getTransactionByIDWithStatus(r.Req.Context(), r.PP["transactionId"], strings.EqualFold(r.QP["history"], "true"))
+			return m.GetTransactionByIDWithStatus(r.Req.Context(), r.PP["transactionId"], strings.EqualFold(r.QP["history"], "true"))
 		},
 	}
 }

--- a/pkg/fftm/transaction_management.go
+++ b/pkg/fftm/transaction_management.go
@@ -28,7 +28,7 @@ import (
 	"github.com/hyperledger/firefly-transaction-manager/pkg/txhandler"
 )
 
-func (m *manager) getTransactionByIDWithStatus(ctx context.Context, txID string, withHistory bool) (transaction *apitypes.TXWithStatus, err error) {
+func (m *manager) GetTransactionByIDWithStatus(ctx context.Context, txID string, withHistory bool) (transaction *apitypes.TXWithStatus, err error) {
 	tx, err := m.persistence.GetTransactionByIDWithStatus(ctx, txID, withHistory)
 	if err != nil {
 		return nil, err

--- a/pkg/fftm/transaction_management_test.go
+++ b/pkg/fftm/transaction_management_test.go
@@ -37,10 +37,10 @@ func TestGetTransactionErrors(t *testing.T) {
 	mp.On("GetTransactionByIDWithStatus", m.ctx, mock.Anything, false).Return(nil, nil).Once()
 	mp.On("Close", mock.Anything).Return(nil).Maybe()
 
-	_, err := m.getTransactionByIDWithStatus(m.ctx, "id", true)
+	_, err := m.GetTransactionByIDWithStatus(m.ctx, "id", true)
 	assert.Regexp(t, "pop", err)
 
-	_, err = m.getTransactionByIDWithStatus(m.ctx, "id", false)
+	_, err = m.GetTransactionByIDWithStatus(m.ctx, "id", false)
 	assert.Regexp(t, "FF21067", err)
 
 	mp.AssertExpectations(t)


### PR DESCRIPTION
The REST API of FFTM exposes straight forward `POST` APIs on top of the `TransactionHandler`:
https://github.com/hyperledger/firefly-transaction-manager/blob/7a882ddaeaf2e7b9b2203a053402576e436debd9/pkg/fftm/route__root_command.go#L86

However, there is no way for an implementation of FFTM (like EVMConnect) to get access to this interface to submit transactions directly, or use the other functions that they implement.

This PR adds a simple accessor to the existing interface.

It also adds `GetTransactionByIDWithStatus()` to enable idempotent submission.