### PR TITLE
fix: duplicate notifications when walkChainForItem fails

### DIFF
--- a/internal/confirmations/confirmations.go
+++ b/internal/confirmations/confirmations.go
@@ -423,12 +423,13 @@ func (bcm *blockConfirmationManager) confirmationsListener() {
 
 		// Process any new notifications - we do this at the end, so it can benefit
 		// from knowing the latest highestBlockSeen
-		if err := bcm.processNotifications(notifications, blocks); err != nil {
-			log.L(bcm.ctx).Errorf("Failed processing notifications: %s", err)
+		// This returns the notifications that were not processed successfully so we store them
+		var err error
+		notifications, err = bcm.processNotifications(notifications, blocks)
+		if err != nil {
+			log.L(bcm.ctx).Errorf("Failed processing notifications: %d due to error %s", len(notifications), err)
 			continue
 		}
-		// Clear the notifications array now we've processed them (we keep the slice memory)
-		notifications = notifications[:0]
 		scheduleAllTxReceipts := !receivedFirstBlock && blockHashCount > 0
 		// Mark receipts stale after duration
 		bcm.scheduleReceiptChecks(scheduleAllTxReceipts)
@@ -455,16 +456,19 @@ func (bcm *blockConfirmationManager) scheduleReceiptChecks(receivedBlocksFirstTi
 	}
 }
 
-func (bcm *blockConfirmationManager) processNotifications(notifications []*Notification, blocks *blockState) error {
-
-	for _, n := range notifications {
+// Returns the notifications that were not processed successfully so that the calling function can remove them
+func (bcm *blockConfirmationManager) processNotifications(notifications []*Notification, blocks *blockState) ([]*Notification, error) {
+	for i, n := range notifications {
 		startTime := time.Now()
 		switch n.NotificationType {
 		case NewEventLog:
 			newItem := n.eventPendingItem()
 			bcm.addOrReplaceItem(newItem)
 			if err := bcm.walkChainForItem(newItem, blocks); err != nil {
-				return err
+				// If we error, we should return the remaining notifications to be processed later
+				// so that the calling function can remove the ones that were processed successfully
+				// This still guarantees ordering of the notifications that were processed successfully
+				return notifications[i:], err
 			}
 		case NewTransaction:
 			newItem := n.transactionPendingItem()
@@ -485,7 +489,8 @@ func (bcm *blockConfirmationManager) processNotifications(notifications []*Notif
 		bcm.metricsEmitter.RecordNotificationProcessMetrics(bcm.ctx, string(n.NotificationType), time.Since(startTime).Seconds())
 	}
 
-	return nil
+	// Clear the notifications slice
+	return []*Notification{}, nil
 }
 
 func (bcm *blockConfirmationManager) dispatchReceipt(pending *pendingItem, receipt *ffcapi.TransactionReceiptResponse, blocks *blockState) {

--- a/internal/confirmations/confirmations.go
+++ b/internal/confirmations/confirmations.go
@@ -427,7 +427,7 @@ func (bcm *blockConfirmationManager) confirmationsListener() {
 		var err error
 		notifications, err = bcm.processNotifications(notifications, blocks)
 		if err != nil {
-			log.L(bcm.ctx).Errorf("Failed processing notifications: %d due to error %s", len(notifications), err)
+			log.L(bcm.ctx).Errorf("Confirmation listener processed %d block hashes and failed processing notifications: %d/%d due to error %s, trigger type: %s", blockHashCount, len(notifications), notificationCount, err, triggerType)
 			continue
 		}
 		scheduleAllTxReceipts := !receivedFirstBlock && blockHashCount > 0


### PR DESCRIPTION
The was a bug in the way the notifications were processed where we end up with notifications not being removed.

When a new notification of type `EventLog`  is processed that is not at the head of the chain, we walk up the chain to verify it. We do this for each notification we have in memory to process in the confirmations manager loop. The existing code exits the loop (continue) if any of the process notifications fail. So let's say we fail to fetch a block for networking issues/rate limiting when walking up the chain for the Nth of M notifications, we don't mark the previous N notifications as successful but keep them in memory. 

This means the notifications are constantly being added and removed from the pending map, but not from the notification buffer that controls if things are inflight and can be dispatched to consumers. The problem gets worse when the getBlockByNumber fails more regularly and the buffer gets so large that eventually if it fails once in many tries is just stall the whole stream.


This PR attempts to fix this by returning which notifications were *not* processed, so the caller can clear those and just have the one in memory that do need processing reducing this problem. The clients in the connectors need to enable retry on the getBlockNumber calls to harden this.

There is also a potential issue if the block we are fetching to walk the chain is so old that is no longer available in the node wondering if @Chengxuan has any thoughts here if we should have a mode where if we are way behind and we don't have node that has the block we can optimistically confirm the event.
 

