### PR TITLE
fix: do not recreate a new notifications slice

### DIFF
--- a/internal/confirmations/confirmations.go
+++ b/internal/confirmations/confirmations.go
@@ -490,7 +490,7 @@ func (bcm *blockConfirmationManager) processNotifications(notifications []*Notif
 	}
 
 	// Clear the notifications slice
-	return []*Notification{}, nil
+	return notifications[:0], nil
 }
 
 func (bcm *blockConfirmationManager) dispatchReceipt(pending *pendingItem, receipt *ffcapi.TransactionReceiptResponse, blocks *blockState) {


### PR DESCRIPTION
We shouldn't be changing the notification array memory location as it's being read in a select statement 

`case notification := <-bcm.bcmNotifications:` 


