### PR TITLE
adding transaction listing index

### DIFF
--- a/db/migrations/postgres/000012_add_transactions_list_index.down.sql
+++ b/db/migrations/postgres/000012_add_transactions_list_index.down.sql
@@ -1,5 +1,5 @@
 BEGIN;
-DROP INDEX IF EXISTS transactions_from_status_nonce;
+DROP INDEX IF EXISTS transactions_from_pending_nonce;
 DROP INDEX IF EXISTS transactions_created;
 COMMIT;
 

--- a/db/migrations/postgres/000012_add_transactions_list_index.down.sql
+++ b/db/migrations/postgres/000012_add_transactions_list_index.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+DROP INDEX IF EXISTS transactions_from_status_nonce;
+DROP INDEX IF EXISTS transactions_created;
+COMMIT;
+

--- a/db/migrations/postgres/000012_add_transactions_list_index.up.sql
+++ b/db/migrations/postgres/000012_add_transactions_list_index.up.sql
@@ -1,7 +1,7 @@
 BEGIN;
--- Composite index to optimize queries filtering by from address, status, and nonce
+-- Composite index to optimize queries filtering by from address, and nonce for pending transactions
 -- This index significantly improves fetching unprocessed transactions for a specific from address with nonce filtering
-CREATE INDEX transactions_from_status_nonce ON transactions(tx_from, status, tx_nonce);
+CREATE INDEX transactions_from_pending_nonce ON transactions(tx_from, tx_nonce) WHERE status = 'Pending';
 
 -- Index on created timestamp to optimize queries filtering or sorting by creation time
 CREATE INDEX transactions_created ON transactions(created);

--- a/db/migrations/postgres/000012_add_transactions_list_index.up.sql
+++ b/db/migrations/postgres/000012_add_transactions_list_index.up.sql
@@ -1,0 +1,10 @@
+BEGIN;
+-- Composite index to optimize queries filtering by from address, status, and nonce
+-- This index significantly improves fetching unprocessed transactions for a specific from address with nonce filtering
+CREATE INDEX transactions_from_status_nonce ON transactions(tx_from, status, tx_nonce);
+
+-- Index on created timestamp to optimize queries filtering or sorting by creation time
+CREATE INDEX transactions_created ON transactions(created);
+
+COMMIT;
+


### PR DESCRIPTION
This PR adds 2 indices that helps on transaction listing when the number of transaction rows grows significantly:

- a composite index of from,status and nonce for the transaction handler to fetch unprocessed transactions for a give "from" address
- an index on `created` for time window based list queries


# NOTE: for a DB with a large volume of **PENDING** transaction records, this new migration could take a long time to run